### PR TITLE
Remove several panics in write_image

### DIFF
--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -474,7 +474,11 @@ impl<'a, W: Write + Seek, T: ColorType> ImageEncoder<'a, W, T> {
     {
         // TODO: Compression
         let samples = self.next_strip_sample_count();
-        assert_eq!(value.len() as u64, samples);
+        if value.len() as u64 != samples {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "Slice is wrong size for strip").into());
+        }
 
         let offset = self.encoder.write_data(value)?;
         self.strip_offsets.push(offset as u32);

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -6,7 +6,7 @@ use tiff::encoder::{colortype, TiffEncoder};
 use tiff::ColorType;
 
 use std::fs::File;
-use std::io::{Seek, SeekFrom};
+use std::io::{Cursor, Seek, SeekFrom};
 
 #[test]
 fn encode_decode() {
@@ -38,6 +38,21 @@ fn encode_decode() {
         }
     }
 }
+
+#[test]
+/// Test that attempting to encode when the input buffer is undersized returns
+/// an error rather than panicking.
+/// See: https://github.com/PistonDevelopers/image-tiff/issues/35
+fn test_encode_undersized_buffer() {
+    let input_data = vec![1, 2, 3];
+    let output = Vec::new();
+    let mut output_stream = Cursor::new(output);
+    if let Ok(mut tiff) = TiffEncoder::new(&mut output_stream) {
+        let res = tiff.write_image::<colortype::RGB8>(50, 50, &input_data);
+        assert!(res.is_err());
+    }
+}
+
 
 #[test]
 fn test_gray_u8_roundtrip() {


### PR DESCRIPTION
Closes #35. It's not decided this is the preferred behavior, but my opinion is that since `write_image` returns a result rather than `()`, the least surprising behavior is to panic in as few cases as possible. It's ambiguous whether `InvalidData` or `UnexpectedEof` would be more appropriate here.

The buffer length is compared vs `width * height` to avoid a redundant comparison for every strip (because Rust still doesn't have non-panicking range indexing 🙁), but this limits the `width * height` to `u32`, so would have to change if BigTIFF support is planned.

Two other unwraps are converted to trys. These should be uncontroversial.