### PR TITLE
Change minimal rustc version to 1.24.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: rust
 rust:
-  - stable
-  - beta
-  - nightly
+    - 1.24.1
+    - stable
+    - beta
+    - nightly

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::io::{self, Read, Seek};
+use std::mem;
 
 use super::stream::{ByteOrder, EndianReader, SmartReader};
 use {TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
@@ -27,9 +28,9 @@ macro_rules! tags {
                 }
             }
             pub fn to_u16(&self) -> u16 {
-                match self {
+                match *self {
                     $( Tag::$tag => $val, )*
-                    Tag::Unknown(n) => *n,
+                    Tag::Unknown(n) => n,
                 }
             }
         }
@@ -174,7 +175,7 @@ impl Entry {
                 ]))
             }
             (Type::SHORT, n) => {
-                if n as usize > limits.decoding_buffer_size / std::mem::size_of::<Value>() {
+                if n as usize > limits.decoding_buffer_size / mem::size_of::<Value>() {
                     return Err(TiffError::LimitsExceeded);
                 }
                 let mut v = Vec::with_capacity(n as usize);
@@ -186,7 +187,7 @@ impl Entry {
             }
             (Type::LONG, 1) => Ok(Unsigned(try!(self.r(bo).read_u32()))),
             (Type::LONG, n) => {
-                if n as usize > limits.decoding_buffer_size / std::mem::size_of::<Value>() {
+                if n as usize > limits.decoding_buffer_size / mem::size_of::<Value>() {
                     return Err(TiffError::LimitsExceeded);
                 }
                 let mut v = Vec::with_capacity(n as usize);
@@ -203,7 +204,7 @@ impl Entry {
                 Ok(Rational(numerator, denominator))
             }
             (Type::RATIONAL, n) => {
-                if n as usize > limits.decoding_buffer_size / std::mem::size_of::<Value>() {
+                if n as usize > limits.decoding_buffer_size / mem::size_of::<Value>() {
                     return Err(TiffError::LimitsExceeded);
                 }
                 let mut v = Vec::with_capacity(n as usize);

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,6 +1,7 @@
 use num_traits::{FromPrimitive, Num};
 use std::collections::HashMap;
 use std::io::{self, Read, Seek};
+use std::cmp;
 
 use {ColorType, TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
@@ -38,7 +39,7 @@ impl DecodingResult {
     }
 
     pub fn as_buffer(&mut self, start: usize) -> DecodingBuffer {
-        match self {
+        match *self {
             DecodingResult::U8(ref mut buf) => DecodingBuffer::U8(&mut buf[start..]),
             DecodingResult::U16(ref mut buf) => DecodingBuffer::U16(&mut buf[start..]),
         }
@@ -55,14 +56,14 @@ pub enum DecodingBuffer<'a> {
 
 impl<'a> DecodingBuffer<'a> {
     fn len(&self) -> usize {
-        match self {
+        match *self {
             DecodingBuffer::U8(ref buf) => buf.len(),
             DecodingBuffer::U16(ref buf) => buf.len(),
         }
     }
 
     fn byte_len(&self) -> usize {
-        match self {
+        match *self {
             DecodingBuffer::U8(_) => 1,
             DecodingBuffer::U16(_) => 2,
         }
@@ -72,7 +73,7 @@ impl<'a> DecodingBuffer<'a> {
     where
         'a: 'b,
     {
-        match self {
+        match *self {
             DecodingBuffer::U8(ref mut buf) => DecodingBuffer::U8(buf),
             DecodingBuffer::U16(ref mut buf) => DecodingBuffer::U16(buf),
         }
@@ -661,7 +662,7 @@ impl<R: Read + Seek> Decoder<R> {
             .get_tag_u32(ifd::Tag::RowsPerStrip)
             .unwrap_or(self.height) as usize;
 
-        let strip_height = std::cmp::min(
+        let strip_height = cmp::min(
             rows_per_strip,
             self.height as usize - index * rows_per_strip,
         );
@@ -716,7 +717,7 @@ impl<R: Read + Seek> Decoder<R> {
             .get_tag_u32(ifd::Tag::RowsPerStrip)
             .unwrap_or(self.height) as usize;
 
-        let strip_height = std::cmp::min(
+        let strip_height = cmp::min(
             rows_per_strip,
             self.height as usize - index * rows_per_strip,
         );

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -1,4 +1,4 @@
-use crate::decoder::PhotometricInterpretation;
+use decoder::PhotometricInterpretation;
 
 /// Trait for different colortypes that can be encoded.
 pub trait ColorType {

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -1,4 +1,4 @@
-use crate::error::TiffResult;
+use error::TiffResult;
 use byteorder::{BigEndian, ByteOrder, LittleEndian, NativeEndian, WriteBytesExt};
 use std::io::{self, Seek, SeekFrom, Write};
 

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -1,6 +1,6 @@
 extern crate tiff;
 
-use tiff::decoder::{ifd::Tag, ifd::Value, Decoder, DecodingResult};
+use tiff::decoder::{ifd, Decoder, DecodingResult};
 use tiff::ColorType;
 
 use std::fs::File;
@@ -52,9 +52,9 @@ fn test_string_tags() {
         let path = format!("./tests/images/{}", filename);
         let img_file = File::open(path).expect("can't open file");
         let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-        let software = decoder.get_tag(Tag::Software).unwrap();
+        let software = decoder.get_tag(ifd::Tag::Software).unwrap();
         match software {
-            Value::Ascii(s) => assert_eq!(
+            ifd::Value::Ascii(s) => assert_eq!(
                 s,
                 String::from("GraphicsMagick 1.2 unreleased Q16 http://www.GraphicsMagick.org/")
             ),


### PR DESCRIPTION
The image crate has `rustc` version 1.24.1 as minimal supported version, however some of the newer PRs in this crates has used new rust features that is not supported by this verison. This PR adds `rustc` 1.24.1 as a travis target and fixes the parts which are not supported in rust 1.24.1

See also discussion in https://github.com/image-rs/image/pull/922