### PR TITLE
Bump version to 0.3.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiff"
-version = "0.3.0"
+version = "0.3.1"
 authors = [
     "ccgn",
     "bvssvni <bvssvni@gmail.com>",


### PR DESCRIPTION
There are no function changes from 0.3 but the compiler requirements
have been lowered. This avoids having to make a decision on `image`
right now, which would delay valuable bug fixes and improvements.

Mostly for documentation purposes to push the release this way.