### PR TITLE
Old-style DEFLATE compression support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ byteorder = "1.2"
 lzw = "0.10"
 num-derive = "0.3"
 num-traits = "0.2"
-libflate = "0.1" # TODO: Put behind a feature?
+miniz_oxide = "0.3" # TODO: Put behind a feature?
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ byteorder = "1.2"
 lzw = "0.10"
 num-derive = "0.3"
 num-traits = "0.2"
+libflate = "0.1" # TODO: Put behind a feature?
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ byteorder = "1.2"
 lzw = "0.10"
 num-derive = "0.3"
 num-traits = "0.2"
-miniz_oxide = "0.3" # TODO: Put behind a feature?
+miniz_oxide = "0.3"
 
 [dev-dependencies]
 tempfile = "3.0"

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -7,7 +7,7 @@ use {ColorType, TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
 use self::ifd::Directory;
 
-use self::stream::{ByteOrder, EndianReader, LZWReader, PackBitsReader, SmartReader};
+use self::stream::{ByteOrder, EndianReader, LZWReader, DeflateReader, PackBitsReader, SmartReader};
 
 pub mod ifd;
 mod stream;
@@ -577,6 +577,12 @@ impl<R: Read + Seek> Decoder<R> {
                     order,
                     length as usize
                 )?;
+                (bytes, Box::new(reader))
+            }
+            CompressionMethod::OldDeflate => {
+                let (bytes, reader) = DeflateReader::new(
+                    &mut self.reader,
+                    max_uncompressed_length)?;
                 (bytes, Box::new(reader))
             }
             method => {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -580,9 +580,7 @@ impl<R: Read + Seek> Decoder<R> {
                 (bytes, Box::new(reader))
             }
             CompressionMethod::OldDeflate => {
-                let (bytes, reader) = DeflateReader::new(
-                    &mut self.reader,
-                    max_uncompressed_length)?;
+                let (bytes, reader) = DeflateReader::new(&mut self.reader)?;
                 (bytes, Box::new(reader))
             }
             method => {

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -100,6 +100,8 @@ pub enum CompressionMethod {
     Fax4 = 4,
     LZW = 5,
     JPEG = 6,
+    Deflate = 8,
+    OldDeflate = 0x80B2,
     PackBits = 0x8005,
 }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -580,7 +580,7 @@ impl<R: Read + Seek> Decoder<R> {
                 (bytes, Box::new(reader))
             }
             CompressionMethod::OldDeflate => {
-                let (bytes, reader) = DeflateReader::new(&mut self.reader)?;
+                let (bytes, reader) = DeflateReader::new(&mut self.reader, max_uncompressed_length)?;
                 (bytes, Box::new(reader))
             }
             method => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -67,15 +67,15 @@ pub struct InflateError {
     status: TINFLStatus,
 }
 
-impl From<TINFLStatus> for TiffFormatError {
-    fn from(status: TINFLStatus) -> Self {
-        TiffFormatError::InflateError(InflateError { status })
+impl InflateError {
+    pub fn new(status: TINFLStatus) -> Self {
+        Self { status }
     }
 }
 
-impl From<TINFLStatus> for TiffError {
-    fn from(status: TINFLStatus) -> Self {
-        TiffError::FormatError(status.into())
+impl TiffError {
+    pub(crate) fn from_inflate_status(status: TINFLStatus) -> Self {
+        TiffError::FormatError(TiffFormatError::InflateError(InflateError::new(status)))
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -138,7 +138,7 @@ impl Error for TiffError {
         }
     }
 
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<& dyn Error> {
         match *self {
             TiffError::IoError(ref e) => Some(e),
             _ => None,

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,7 @@ use std::string;
 
 use decoder::ifd::{Tag, Value};
 use decoder::{CompressionMethod, PhotometricInterpretation, PlanarConfiguration};
+use miniz_oxide::inflate::TINFLStatus;
 use ColorType;
 
 /// Tiff error kinds.
@@ -34,6 +35,7 @@ pub enum TiffFormatError {
     UnknownPredictor(u32),
     UnsignedIntegerExpected(Value),
     SignedIntegerExpected(Value),
+    InflateError(InflateError),
 }
 
 impl fmt::Display for TiffFormatError {
@@ -55,7 +57,25 @@ impl fmt::Display for TiffFormatError {
             SignedIntegerExpected(ref val) => {
                 write!(fmt, "Expected signed integer, {:?} found.", val)
             }
+            InflateError(_) => write!(fmt, "Failed to decode inflate data."),
         }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct InflateError {
+    status: TINFLStatus,
+}
+
+impl From<TINFLStatus> for TiffFormatError {
+    fn from(status: TINFLStatus) -> Self {
+        TiffFormatError::InflateError(InflateError { status })
+    }
+}
+
+impl From<TINFLStatus> for TiffError {
+    fn from(status: TINFLStatus) -> Self {
+        TiffError::FormatError(status.into())
     }
 }
 
@@ -138,7 +158,7 @@ impl Error for TiffError {
         }
     }
 
-    fn cause(&self) -> Option<& dyn Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             TiffError::IoError(ref e) => Some(e),
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 extern crate byteorder;
 extern crate lzw;
+extern crate libflate;
 #[macro_use]
 extern crate num_derive;
 extern crate num_traits;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@
 
 extern crate byteorder;
 extern crate lzw;
-extern crate libflate;
+extern crate miniz_oxide;
 #[macro_use]
 extern crate num_derive;
 extern crate num_traits;


### PR DESCRIPTION
Has not been tested on many images, but seems to work with ones I have. Only enabled for the 0x80B2 magic, but may also work for 0x0008. 