### PR TITLE
Experimental support multiple channels beyond RGBA/CMYK/etc.

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -352,7 +352,6 @@ impl<R: Read + Seek> Decoder<R> {
         };
         if let Some(val) = try!(self.find_tag_u32(ifd::Tag::Compression)) {
             match FromPrimitive::from_u32(val) {
-                
                 Some(method) => self.compression_method = method,
                 None => {
                     return Err(TiffError::UnsupportedError(
@@ -360,7 +359,6 @@ impl<R: Read + Seek> Decoder<R> {
                     ))
                 }
             }
-           self.compression_method = CompressionMethod::None;
         }
         if let Some(val) = try!(self.find_tag_u32(ifd::Tag::SamplesPerPixel)) {
             self.samples = val as u8

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -202,6 +202,7 @@ fn rev_hpredict(image: DecodingBuffer, size: (u32, u32), color_type: ColorType) 
         ColorType::Gray(8) | ColorType::Gray(16) => 1,
         ColorType::RGB(8) | ColorType::RGB(16) => 3,
         ColorType::RGBA(8) | ColorType::RGBA(16) | ColorType::CMYK(8) => 4,
+        ColorType::Other(sample_bits) => sample_bits.len(),
         _ => {
             return Err(TiffError::UnsupportedError(
                 TiffUnsupportedError::HorizontalPredictor(color_type),

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -19,9 +19,6 @@ pub enum DecodingResult {
     U8(Vec<u8>),
     /// A vector of unsigned words
     U16(Vec<u16>),
-    /// Potentially mixed image types
-    //TODO: Check for all u16s and all u8s and act accordingly?
-    Mixed(Vec<u8>),
 }
 
 impl DecodingResult {
@@ -30,14 +27,6 @@ impl DecodingResult {
             Err(TiffError::LimitsExceeded)
         } else {
             Ok(DecodingResult::U8(vec![0; size]))
-        }
-    }
-
-    fn new_mixed(size: usize, limits: &Limits) -> TiffResult<DecodingResult> {
-        if size > limits.decoding_buffer_size {
-            Err(TiffError::LimitsExceeded)
-        } else {
-            Ok(DecodingResult::Mixed(vec![0; size]))
         }
     }
 
@@ -52,7 +41,6 @@ impl DecodingResult {
     pub fn as_buffer(&mut self, start: usize) -> DecodingBuffer {
         match *self {
             DecodingResult::U8(ref mut buf) => DecodingBuffer::U8(&mut buf[start..]),
-            DecodingResult::Mixed(ref mut buf) => DecodingBuffer::Mixed(&mut buf[start..]),
             DecodingResult::U16(ref mut buf) => DecodingBuffer::U16(&mut buf[start..]),
         }
     }
@@ -64,8 +52,6 @@ pub enum DecodingBuffer<'a> {
     U8(&'a mut [u8]),
     /// A slice of unsigned words
     U16(&'a mut [u16]),
-    /// A slice of potentially mixed image types 
-    Mixed(&'a mut [u8]),
 }
 
 impl<'a> DecodingBuffer<'a> {
@@ -73,7 +59,6 @@ impl<'a> DecodingBuffer<'a> {
         match *self {
             DecodingBuffer::U8(ref buf) => buf.len(),
             DecodingBuffer::U16(ref buf) => buf.len(),
-            DecodingBuffer::Mixed(ref buf) => buf.len(),
         }
     }
 
@@ -81,7 +66,6 @@ impl<'a> DecodingBuffer<'a> {
         match *self {
             DecodingBuffer::U8(_) => 1,
             DecodingBuffer::U16(_) => 2,
-            DecodingBuffer::Mixed(_) => 1,
         }
     }
 
@@ -92,7 +76,6 @@ impl<'a> DecodingBuffer<'a> {
         match *self {
             DecodingBuffer::U8(ref mut buf) => DecodingBuffer::U8(buf),
             DecodingBuffer::U16(ref mut buf) => DecodingBuffer::U16(buf),
-            DecodingBuffer::Mixed(ref mut buf) => DecodingBuffer::Mixed(buf),
         }
     }
 }
@@ -230,9 +213,6 @@ fn rev_hpredict(image: DecodingBuffer, size: (u32, u32), color_type: ColorType) 
             rev_hpredict_nsamp(buf, size, samples);
         }
         DecodingBuffer::U16(buf) => {
-            rev_hpredict_nsamp(buf, size, samples);
-        }
-        DecodingBuffer::Mixed(buf) => {
             rev_hpredict_nsamp(buf, size, samples);
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -62,7 +62,6 @@ pub enum TiffUnsupportedError {
     UnknownInterpretation,
     UnknownCompressionMethod,
     UnsupportedCompressionMethod(CompressionMethod),
-    UnsupportedSampleDepth(u8),
     UnsupportedColorType(ColorType),
     UnsupportedBitsPerChannel(u8),
     UnsupportedPlanarConfig(Option<PlanarConfiguration>),
@@ -72,7 +71,7 @@ pub enum TiffUnsupportedError {
 impl fmt::Display for TiffUnsupportedError {
     fn fmt(&self, fmt: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         use self::TiffUnsupportedError::*;
-        match *self {
+        match self {
             HorizontalPredictor(color_type) => write!(
                 fmt,
                 "Horizontal predictor for {:?} is unsupported.",
@@ -90,9 +89,6 @@ impl fmt::Display for TiffUnsupportedError {
             UnknownCompressionMethod => write!(fmt, "Unknown compression method."),
             UnsupportedCompressionMethod(method) => {
                 write!(fmt, "Compression method {:?} is unsupported", method)
-            }
-            UnsupportedSampleDepth(samples) => {
-                write!(fmt, "{} samples per pixel is supported.", samples)
             }
             UnsupportedColorType(color_type) => {
                 write!(fmt, "Color type {:?} is unsupported", color_type)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ mod error;
 pub use self::error::{TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
 /// An enumeration over supported color types and their bit depths
-#[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]
+#[derive(PartialEq, Eq, Debug, Clone, Hash)]
 pub enum ColorType {
     /// Pixel is grayscale
     Gray(u8),
@@ -38,4 +38,7 @@ pub enum ColorType {
 
     /// Pixel is CMYK
     CMYK(u8),
+
+    /// Other color types (Such as multi-channel)
+    Other(Box<[u8]>),
 }

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -10,7 +10,7 @@ fn test_gray_u8() {
     let img_file =
         File::open("./tests/images/minisblack-1c-8b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
+    assert_eq!(decoder.colortype(), ColorType::Gray(8));
     let img_res = decoder.read_image();
     assert!(img_res.is_ok());
 }
@@ -19,7 +19,7 @@ fn test_gray_u8() {
 fn test_rgb_u8() {
     let img_file = File::open("./tests/images/rgb-3c-8b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
+    assert_eq!(decoder.colortype(), ColorType::RGB(8));
     let img_res = decoder.read_image();
     assert!(img_res.is_ok());
 }
@@ -29,7 +29,7 @@ fn test_gray_u16() {
     let img_file =
         File::open("./tests/images/minisblack-1c-16b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(16));
+    assert_eq!(decoder.colortype(), ColorType::Gray(16));
     let img_res = decoder.read_image();
     assert!(img_res.is_ok());
 }
@@ -38,7 +38,7 @@ fn test_gray_u16() {
 fn test_rgb_u16() {
     let img_file = File::open("./tests/images/rgb-3c-16b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(16));
+    assert_eq!(decoder.colortype(), ColorType::RGB(16));
     let img_res = decoder.read_image();
     assert!(img_res.is_ok());
 }
@@ -76,7 +76,7 @@ fn test_decode_data() {
     }
     let file = File::open("./tests/decodedata-rgb-3c-8b.tiff").unwrap();
     let mut decoder = Decoder::new(file).unwrap();
-    assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
+    assert_eq!(decoder.colortype(), ColorType::RGB(8));
     assert_eq!(decoder.dimensions().unwrap(), (100, 100));
     if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
         assert_eq!(image_data, img_res);
@@ -91,7 +91,7 @@ fn test_decode_data() {
 //{
 //let img_file = File::open("./tests/images/minisblack-2c-8b-alpha.tiff").expect("Cannot find test image!");
 //let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-//assert_eq!(decoder.colortype().unwrap(), ColorType::GrayA(8));
+//assert_eq!(decoder.colortype(), ColorType::GrayA(8));
 //let img_res = decoder.read_image();
 //assert!(img_res.is_ok());
 //}

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -29,7 +29,7 @@ fn encode_decode() {
     {
         file.seek(SeekFrom::Start(0)).unwrap();
         let mut decoder = Decoder::new(&mut file).unwrap();
-        assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
+        assert_eq!(decoder.colortype(), ColorType::RGB(8));
         assert_eq!(decoder.dimensions().unwrap(), (100, 100));
         if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
             assert_eq!(image_data, img_res);
@@ -59,7 +59,7 @@ fn test_gray_u8_roundtrip() {
     let img_file =
         File::open("./tests/images/minisblack-1c-8b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(8));
+    assert_eq!(decoder.colortype(), ColorType::Gray(8));
 
     let image_data = match decoder.read_image().unwrap() {
         DecodingResult::U8(res) => res,
@@ -89,7 +89,7 @@ fn test_gray_u8_roundtrip() {
 fn test_rgb_u8_roundtrip() {
     let img_file = File::open("./tests/images/rgb-3c-8b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
+    assert_eq!(decoder.colortype(), ColorType::RGB(8));
 
     let image_data = match decoder.read_image().unwrap() {
         DecodingResult::U8(res) => res,
@@ -120,7 +120,7 @@ fn test_gray_u16_roundtrip() {
     let img_file =
         File::open("./tests/images/minisblack-1c-16b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::Gray(16));
+    assert_eq!(decoder.colortype(), ColorType::Gray(16));
 
     let image_data = match decoder.read_image().unwrap() {
         DecodingResult::U16(res) => res,
@@ -150,7 +150,7 @@ fn test_gray_u16_roundtrip() {
 fn test_rgb_u16_roundtrip() {
     let img_file = File::open("./tests/images/rgb-3c-16b.tiff").expect("Cannot find test image!");
     let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
-    assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(16));
+    assert_eq!(decoder.colortype(), ColorType::RGB(16));
 
     let image_data = match decoder.read_image().unwrap() {
         DecodingResult::U16(res) => res,


### PR DESCRIPTION
Support multiple channels per image. The implementation here could definitely be improved (For images with information such as mixed 8 and 16 channels). Should also be trivial to merge with deflate support.