### PR TITLE
update num-derive to 0.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-    - 1.24.1
+    - 1.34.2
     - stable
     - beta
     - nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 [dependencies]
 byteorder = "1.2"
 lzw = "0.10"
-num-derive = "0.2"
+num-derive = "0.3"
 num-traits = "0.2"
 
 [dev-dependencies]


### PR DESCRIPTION
In an effort to reduce duplicate dependency versions in projects, update `num-derive` to 0.3, which upgrades `proc-macro2`, `quote` and `syn` to version 1

For the updated num-derive to work the minimal rustc version becomes 1.32.0. We bump it to 1.34.2 for consistency and to accomodate other changes.