### PR TITLE
Multipage image patch

### DIFF
--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -10,6 +10,7 @@ impl TiffByteOrder for LittleEndian {
     fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {
         writer.writer.write_u16::<LittleEndian>(0x4949)?;
         writer.writer.write_u16::<LittleEndian>(42)?;
+        writer.offset += 4;
 
         Ok(())
     }
@@ -19,6 +20,7 @@ impl TiffByteOrder for BigEndian {
     fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {
         writer.writer.write_u16::<BigEndian>(0x4d4d)?;
         writer.writer.write_u16::<BigEndian>(42)?;
+        writer.offset += 4;
 
         Ok(())
     }
@@ -26,67 +28,77 @@ impl TiffByteOrder for BigEndian {
 
 pub struct TiffWriter<W> {
     writer: W,
+    offset: u64,
 }
 
 impl<W: Write> TiffWriter<W> {
     pub fn new(writer: W) -> Self {
-        Self { writer }
+        Self { writer, offset: 0 }
+    }
+
+    pub fn offset(&self) -> u64 {
+        self.offset
     }
 
     pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), io::Error> {
         self.writer.write_all(bytes)?;
+        self.offset += bytes.len() as u64;
         Ok(())
     }
 
     pub fn write_u8(&mut self, n: u8) -> Result<(), io::Error> {
         self.writer.write_u8(n)?;
+        self.offset += 1;
         Ok(())
     }
 
     pub fn write_i8(&mut self, n: i8) -> Result<(), io::Error> {
         self.writer.write_i8(n)?;
+        self.offset += 1;
         Ok(())
     }
 
     pub fn write_u16(&mut self, n: u16) -> Result<(), io::Error> {
         self.writer.write_u16::<NativeEndian>(n)?;
+        self.offset += 2;
 
         Ok(())
     }
 
     pub fn write_i16(&mut self, n: i16) -> Result<(), io::Error> {
         self.writer.write_i16::<NativeEndian>(n)?;
+        self.offset += 2;
 
         Ok(())
     }
 
     pub fn write_u32(&mut self, n: u32) -> Result<(), io::Error> {
         self.writer.write_u32::<NativeEndian>(n)?;
+        self.offset += 4;
 
         Ok(())
     }
 
     pub fn write_i32(&mut self, n: i32) -> Result<(), io::Error> {
         self.writer.write_i32::<NativeEndian>(n)?;
+        self.offset += 4;
 
         Ok(())
     }
 
     pub fn write_u64(&mut self, n: u64) -> Result<(), io::Error> {
         self.writer.write_u64::<NativeEndian>(n)?;
+        self.offset += 8;
 
         Ok(())
     }
 
-}
-
-impl<W: Write + Seek> TiffWriter<W> {
     pub fn pad_word_boundary(&mut self) -> Result<(), io::Error> {
-        let offset = self.offset();
-        if offset % 4 != 0 {
+        if self.offset % 4 != 0 {
             let padding = [0, 0, 0];
-            let padd_len = 4 - (offset % 4);
+            let padd_len = 4 - (self.offset % 4);
             self.writer.write_all(&padding[..padd_len as usize])?;
+            self.offset += padd_len;
         }
 
         Ok(())
@@ -95,11 +107,8 @@ impl<W: Write + Seek> TiffWriter<W> {
 
 impl<W: Seek> TiffWriter<W> {
     pub fn goto_offset(&mut self, offset: u64) -> Result<(), io::Error> {
+        self.offset = offset;
         self.writer.seek(SeekFrom::Start(offset as u64))?;
         Ok(())
-    }
-
-    pub fn offset(&mut self) -> u64 {
-        self.writer.seek(SeekFrom::Current(0)).unwrap()
     }
 }

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -10,7 +10,6 @@ impl TiffByteOrder for LittleEndian {
     fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {
         writer.writer.write_u16::<LittleEndian>(0x4949)?;
         writer.writer.write_u16::<LittleEndian>(42)?;
-        writer.offset += 4;
 
         Ok(())
     }
@@ -20,7 +19,6 @@ impl TiffByteOrder for BigEndian {
     fn write_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {
         writer.writer.write_u16::<BigEndian>(0x4d4d)?;
         writer.writer.write_u16::<BigEndian>(42)?;
-        writer.offset += 4;
 
         Ok(())
     }
@@ -28,75 +26,66 @@ impl TiffByteOrder for BigEndian {
 
 pub struct TiffWriter<W> {
     writer: W,
-    offset: u64,
 }
 
 impl<W: Write> TiffWriter<W> {
     pub fn new(writer: W) -> Self {
-        Self { writer, offset: 0 }
-    }
-
-    pub fn offset(&self) -> u64 {
-        self.offset
+        Self { writer }
     }
 
     pub fn write_bytes(&mut self, bytes: &[u8]) -> Result<(), io::Error> {
         self.writer.write_all(bytes)?;
-        self.offset += bytes.len() as u64;
         Ok(())
     }
 
     pub fn write_u8(&mut self, n: u8) -> Result<(), io::Error> {
         self.writer.write_u8(n)?;
-        self.offset += 1;
         Ok(())
     }
 
     pub fn write_i8(&mut self, n: i8) -> Result<(), io::Error> {
         self.writer.write_i8(n)?;
-        self.offset += 1;
         Ok(())
     }
 
     pub fn write_u16(&mut self, n: u16) -> Result<(), io::Error> {
         self.writer.write_u16::<NativeEndian>(n)?;
-        self.offset += 2;
 
         Ok(())
     }
 
     pub fn write_i16(&mut self, n: i16) -> Result<(), io::Error> {
         self.writer.write_i16::<NativeEndian>(n)?;
-        self.offset += 2;
 
         Ok(())
     }
 
     pub fn write_u32(&mut self, n: u32) -> Result<(), io::Error> {
         self.writer.write_u32::<NativeEndian>(n)?;
-        self.offset += 4;
 
         Ok(())
     }
 
     pub fn write_i32(&mut self, n: i32) -> Result<(), io::Error> {
         self.writer.write_i32::<NativeEndian>(n)?;
-        self.offset += 4;
 
         Ok(())
     }
 
     pub fn write_u64(&mut self, n: u64) -> Result<(), io::Error> {
         self.writer.write_u64::<NativeEndian>(n)?;
-        self.offset += 8;
 
         Ok(())
     }
 
+}
+
+impl<W: Write + Seek> TiffWriter<W> {
     pub fn pad_word_boundary(&mut self) -> Result<(), io::Error> {
-        if self.offset % 4 != 0 {
+        let offset = self.offset();
+        if offset % 4 != 0 {
             let padding = [0, 0, 0];
-            let padd_len = 4 - (self.offset % 4);
+            let padd_len = 4 - (offset % 4);
             self.writer.write_all(&padding[..padd_len as usize])?;
         }
 
@@ -106,8 +95,11 @@ impl<W: Write> TiffWriter<W> {
 
 impl<W: Seek> TiffWriter<W> {
     pub fn goto_offset(&mut self, offset: u64) -> Result<(), io::Error> {
-        self.offset = offset;
         self.writer.seek(SeekFrom::Start(offset as u64))?;
         Ok(())
+    }
+
+    pub fn offset(&mut self) -> u64 {
+        self.writer.seek(SeekFrom::Current(0)).unwrap()
     }
 }

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -265,7 +265,7 @@ fn test_signed() {
 #[test]
 /// check multipage image handling
 fn test_multipage_image() {
-    let mut img_file = tempfile::tempfile().unwrap();
+    let mut img_file = Cursor::new(Vec::new());
 
     {
         // first create a multipage image with 2 images

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -269,7 +269,7 @@ fn test_multipage_image() {
 
     {
         // first create a multipage image with 2 images
-        let mut img_encoder = TiffEncoder::new(&img_file).unwrap();
+        let mut img_encoder = TiffEncoder::new(&mut img_file).unwrap();
 
         // write first grayscale image (2x2 16-bit)
         let img1: Vec<u16> = [1, 2, 3, 4].to_vec();
@@ -283,7 +283,7 @@ fn test_multipage_image() {
     img_file.seek(SeekFrom::Start(0)).unwrap();
 
     {
-        let mut img_decoder = Decoder::new(&img_file).unwrap();
+        let mut img_decoder = Decoder::new(&mut img_file).unwrap();
 
         // check the dimensions of the image in the first page
         assert_eq!(img_decoder.dimensions().unwrap(), (2, 2));

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -261,3 +261,34 @@ fn test_signed() {
         assert_eq!(decoder.get_tag(Tag::Unknown(65031)).unwrap().into_i32_vec().unwrap(), [-1_i32, 100, 2, 100]);
     }
 }
+
+#[test]
+/// check multipage image handling
+fn test_multipage_image() {
+    let mut img_file = tempfile::tempfile().unwrap();
+
+    {
+        // first create a multipage image with 2 images
+        let mut img_encoder = TiffEncoder::new(&img_file).unwrap();
+
+        // write first grayscale image (2x2 16-bit)
+        let img1: Vec<u16> = [1, 2, 3, 4].to_vec();
+        img_encoder.write_image::<colortype::Gray16>(2, 2, &img1[..]);
+        // write second grayscale image (3x3 8-bit)
+        let img2: Vec<u8> = [9, 8, 7, 6, 5, 4, 3, 2, 1].to_vec();
+        img_encoder.write_image::<colortype::Gray8>(3, 3, &img2[..]);
+    }
+
+    // seek to the beginning of the file, so that it can be decoded
+    img_file.seek(SeekFrom::Start(0)).unwrap();
+
+    {
+        let mut img_decoder = Decoder::new(&img_file).unwrap();
+
+        // check the dimensions of the image in the first page
+        assert_eq!(img_decoder.dimensions().unwrap(), (2, 2));
+        img_decoder.next_image().unwrap();
+        // check the dimensions of the image in the second page
+        assert_eq!(img_decoder.dimensions().unwrap(), (3, 3));
+    }
+}


### PR DESCRIPTION
While using image-tiff for multipage image I ran into 2 things:
1. the ifd offset is written twice for each image, which results into that the ifd offset of the second and later images was 0 and followed by the correct location.
2. the returned offset of the TiffWriter was 2 bytes off, starting at the second page. The easiest way to resolve this was by using the seek(SeekFrom::Current(0)) functionality of the writer object, instead of fixing the offset housekeeping.

