### PR TITLE
Replace FromPrimitive with our own tag macro

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 [dependencies]
 byteorder = "1.2"
 lzw = "0.10"
-num-traits = "0.2"
 miniz_oxide = "0.3"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 [dependencies]
 byteorder = "1.2"
 lzw = "0.10"
-num-derive = "0.3"
 num-traits = "0.2"
 miniz_oxide = "0.3"
 

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -10,27 +10,35 @@ use {TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 use self::Value::{Ascii, List, Rational, Unsigned, Signed, SRational};
 
 macro_rules! tags {
-    {$(
-        $tag:ident
-        $val:expr;
-    )*} => {
-
-        /// TIFF tag
-        #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
-        pub enum Tag {
-            $($tag,)*
-            Unknown(u16)
+    {
+        // Permit arbitrary meta items, which include documentation.
+        $( #[$enum_attr:meta] )*
+        pub enum $name:ident($ty:ty) {
+            // Each of the `Name = Val,` permitting documentation.
+            $($(#[$ident_attr:meta])* $tag:ident = $val:expr,)*
         }
-        impl Tag {
-            pub fn from_u16(n: u16) -> Tag {
-                $(if n == $val { Tag::$tag } else)* {
-                    Tag::Unknown(n)
+    } => {
+        $( #[$enum_attr] )*
+        #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+        pub enum $name {
+            $($(#[$ident_attr])* $tag,)*
+            Unknown($ty),
+            #[doc(hidden)]
+            __NonExhaustive,
+        }
+
+        impl $name {
+            fn __from_inner_type(n: u16) -> Self {
+                $(if n == $val { $name::$tag } else)* {
+                    $name::Unknown(n)
                 }
             }
-            pub fn to_u16(&self) -> u16 {
+
+            fn __to_inner_type(&self) -> u16 {
                 match *self {
-                    $( Tag::$tag => $val, )*
-                    Tag::Unknown(n) => n,
+                    $( $name::$tag => $val, )*
+                    $name::Unknown(n) => n,
+                    $name::__NonExhaustive => unreachable!(),
                 }
             }
         }
@@ -39,47 +47,60 @@ macro_rules! tags {
 
 // Note: These tags appear in the order they are mentioned in the TIFF reference
 tags! {
+/// TIFF tags
+pub enum Tag(u16) {
     // Baseline tags:
-    Artist 315;
+    Artist = 315,
     // grayscale images PhotometricInterpretation 1 or 3
-    BitsPerSample 258;
-    CellLength 265; // TODO add support
-    CellWidth 264; // TODO add support
+    BitsPerSample = 258,
+    CellLength = 265, // TODO add support
+    CellWidth = 264, // TODO add support
     // palette-color images (PhotometricInterpretation 3)
-    ColorMap 320; // TODO add support
-    Compression 259; // TODO add support for 2 and 32773
-    Copyright 33_432;
-    DateTime 306;
-    ExtraSamples 338; // TODO add support
-    FillOrder 266; // TODO add support
-    FreeByteCounts 289; // TODO add support
-    FreeOffsets 288; // TODO add support
-    GrayResponseCurve 291; // TODO add support
-    GrayResponseUnit 290; // TODO add support
-    HostComputer 316;
-    ImageDescription 270;
-    ImageLength 257;
-    ImageWidth 256;
-    Make 271;
-    MaxSampleValue 281; // TODO add support
-    MinSampleValue 280; // TODO add support
-    Model 272;
-    NewSubfileType 254; // TODO add support
-    Orientation 274; // TODO add support
-    PhotometricInterpretation 262;
-    PlanarConfiguration 284;
-    ResolutionUnit 296; // TODO add support
-    RowsPerStrip 278;
-    SamplesPerPixel 277;
-    Software 305;
-    StripByteCounts 279;
-    StripOffsets 273;
-    SubfileType 255; // TODO add support
-    Threshholding 263; // TODO add support
-    XResolution 282;
-    YResolution 283;
+    ColorMap = 320, // TODO add support
+    Compression = 259, // TODO add support for 2 and 32773
+    Copyright = 33_432,
+    DateTime = 306,
+    ExtraSamples = 338, // TODO add support
+    FillOrder = 266, // TODO add support
+    FreeByteCounts = 289, // TODO add support
+    FreeOffsets = 288, // TODO add support
+    GrayResponseCurve = 291, // TODO add support
+    GrayResponseUnit = 290, // TODO add support
+    HostComputer = 316,
+    ImageDescription = 270,
+    ImageLength = 257,
+    ImageWidth = 256,
+    Make = 271,
+    MaxSampleValue = 281, // TODO add support
+    MinSampleValue = 280, // TODO add support
+    Model = 272,
+    NewSubfileType = 254, // TODO add support
+    Orientation = 274, // TODO add support
+    PhotometricInterpretation = 262,
+    PlanarConfiguration = 284,
+    ResolutionUnit = 296, // TODO add support
+    RowsPerStrip = 278,
+    SamplesPerPixel = 277,
+    Software = 305,
+    StripByteCounts = 279,
+    StripOffsets = 273,
+    SubfileType = 255, // TODO add support
+    Threshholding = 263, // TODO add support
+    XResolution = 282,
+    YResolution = 283,
     // Advanced tags
-    Predictor 317;
+    Predictor = 317,
+}
+}
+
+impl Tag {
+    pub fn from_u16(val: u16) -> Self {
+        Self::__from_inner_type(val)
+    }
+
+    pub fn to_u16(&self) -> u16 {
+        Self::__to_inner_type(self)
+    }
 }
 
 #[derive(Clone, Copy, Debug, FromPrimitive)]
@@ -93,6 +114,8 @@ pub enum Type {
     SSHORT = 8,
     SLONG = 9,
     SRATIONAL = 10,
+    #[doc(hidden)] // Do not match against this.
+    __NonExhaustive,
 }
 
 #[allow(unused_qualifications)]
@@ -104,6 +127,8 @@ pub enum Value {
     Rational(u32, u32),
     SRational(i32, i32),
     Ascii(String),
+    #[doc(hidden)] // Do not match against this.
+    __NonExhaustive,
 }
 
 impl Value {

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -34,8 +34,9 @@ macro_rules! tags {
         impl $name {
             #[inline(always)]
             fn __from_inner_type(n: $ty) -> Result<Self, $ty> {
-                $(if n == $val { Ok($name::$tag) } else)* {
-                    Err(n)
+                match n {
+                    $( $val => Ok($name::$tag), )*
+                    n => Err(n),
                 }
             }
 

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -13,7 +13,7 @@ macro_rules! tags {
     {
         // Permit arbitrary meta items, which include documentation.
         $( #[$enum_attr:meta] )*
-        pub enum $name:ident($ty:ty) $(unknown($unknown_doc:literal))* {
+        $vis:vis enum $name:ident($ty:ty) $(unknown($unknown_doc:literal))* {
             // Each of the `Name = Val,` permitting documentation.
             $($(#[$ident_attr:meta])* $tag:ident = $val:expr,)*
         }
@@ -33,14 +33,14 @@ macro_rules! tags {
 
         impl $name {
             #[inline(always)]
-            fn __from_inner_type(n: u16) -> Result<Self, $ty> {
+            fn __from_inner_type(n: $ty) -> Result<Self, $ty> {
                 $(if n == $val { Ok($name::$tag) } else)* {
                     Err(n)
                 }
             }
 
             #[inline(always)]
-            fn __to_inner_type(&self) -> u16 {
+            fn __to_inner_type(&self) -> $ty {
                 match *self {
                     $( $name::$tag => $val, )*
                     $( $name::Unknown(n) => { $unknown_doc; n }, )*

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -82,7 +82,7 @@ impl<'a> DecodingBuffer<'a> {
 }
 
 tags! {
-pub enum PhotometricInterpretation(u32) {
+pub enum PhotometricInterpretation(u16) {
     WhiteIsZero = 0,
     BlackIsZero = 1,
     RGB = 2,
@@ -95,7 +95,7 @@ pub enum PhotometricInterpretation(u32) {
 }
 
 tags! {
-pub enum CompressionMethod(u32) {
+pub enum CompressionMethod(u16) {
     None = 1,
     Huffman = 2,
     Fax3 = 3,
@@ -109,55 +109,55 @@ pub enum CompressionMethod(u32) {
 }
 
 tags! {
-pub enum PlanarConfiguration(u32) {
+pub enum PlanarConfiguration(u16) {
     Chunky = 1,
     Planar = 2,
 }
 }
 
 tags! {
-enum Predictor(u32) {
+enum Predictor(u16) {
     None = 1,
     Horizontal = 2,
 }
 }
 
 impl PhotometricInterpretation {
-    pub fn from_u32(val: u32) -> Option<Self> {
+    pub fn from_u16(val: u16) -> Option<Self> {
         Self::__from_inner_type(val).ok()
     }
 
-    pub fn to_u32(&self) -> u32 {
+    pub fn to_u16(&self) -> u16 {
         Self::__to_inner_type(self)
     }
 }
 
 impl CompressionMethod {
-    pub fn from_u32(val: u32) -> Option<Self> {
+    pub fn from_u16(val: u16) -> Option<Self> {
         Self::__from_inner_type(val).ok()
     }
 
-    pub fn to_u32(&self) -> u32 {
+    pub fn to_u16(&self) -> u16 {
         Self::__to_inner_type(self)
     }
 }
 
 impl PlanarConfiguration {
-    pub fn from_u32(val: u32) -> Option<Self> {
+    pub fn from_u16(val: u16) -> Option<Self> {
         Self::__from_inner_type(val).ok()
     }
 
-    pub fn to_u32(&self) -> u32 {
+    pub fn to_u16(&self) -> u16 {
         Self::__to_inner_type(self)
     }
 }
 
 impl Predictor {
-    pub fn from_u32(val: u32) -> Option<Self> {
+    pub fn from_u16(val: u16) -> Option<Self> {
         Self::__from_inner_type(val).ok()
     }
 
-    pub fn to_u32(&self) -> u32 {
+    pub fn to_u16(&self) -> u16 {
         Self::__to_inner_type(self)
     }
 }
@@ -379,8 +379,9 @@ impl<R: Read + Seek> Decoder<R> {
         self.width = self.get_tag_u32(ifd::Tag::ImageWidth)?;
         self.height = self.get_tag_u32(ifd::Tag::ImageLength)?;
         self.strip_decoder = None;
-        self.photometric_interpretation = match PhotometricInterpretation::from_u32(
-            self.get_tag_u32(ifd::Tag::PhotometricInterpretation)?
+        // TODO: error on non-SHORT value.
+        self.photometric_interpretation = match PhotometricInterpretation::from_u16(
+            self.get_tag_u32(ifd::Tag::PhotometricInterpretation)? as u16
         ) {
             Some(val) => val,
             None => {
@@ -389,8 +390,9 @@ impl<R: Read + Seek> Decoder<R> {
                 ))
             }
         };
+        // TODO: error on non-SHORT value.
         if let Some(val) = self.find_tag_u32(ifd::Tag::Compression)? {
-            match CompressionMethod::from_u32(val) {
+            match CompressionMethod::from_u16(val as u16) {
                 Some(method) => self.compression_method = method,
                 None => {
                     return Err(TiffError::UnsupportedError(
@@ -765,7 +767,8 @@ impl<R: Read + Seek> Decoder<R> {
             ));
         }
         if let Ok(predictor) = self.get_tag_u32(ifd::Tag::Predictor) {
-            match Predictor::from_u32(predictor) {
+            // TODO: error on non-SHORT value.
+            match Predictor::from_u16(predictor as u16) {
                 Some(Predictor::None) => (),
                 Some(Predictor::Horizontal) => {
                     rev_hpredict(

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -454,7 +454,7 @@ impl<R: Read + Seek> Decoder<R> {
     // Value 4 bytes either a pointer the value itself
     fn read_entry(&mut self) -> TiffResult<Option<(ifd::Tag, ifd::Entry)>> {
         let tag = ifd::Tag::from_u16(self.read_short()?);
-        let type_: ifd::Type = match FromPrimitive::from_u16(self.read_short()?) {
+        let type_ = match ifd::Type::from_u16(self.read_short()?) {
             Some(t) => t,
             None => {
                 // Unknown type. Skip this entry according to spec.

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1,4 +1,3 @@
-use num_traits::{Num};
 use std::collections::HashMap;
 use std::io::{self, Read, Seek};
 use std::cmp;
@@ -236,7 +235,7 @@ impl Wrapping for u16 {
 
 fn rev_hpredict_nsamp<T>(image: &mut [T], size: (u32, u32), samples: usize)
 where
-    T: Num + Copy + Wrapping,
+    T: Copy + Wrapping,
 {
     let width = size.0 as usize;
     let height = size.1 as usize;

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -438,7 +438,7 @@ impl<'a, W: 'a + Write + Seek> DirectoryEncoder<'a, W> {
         }
 
         self.ifd
-            .insert(tag.to_u16(), (<T>::FIELD_TYPE as u16, value.count(), bytes));
+            .insert(tag.to_u16(), (<T>::FIELD_TYPE.to_u16(), value.count(), bytes));
     }
 
     fn write_directory(&mut self) -> TiffResult<u64> {
@@ -565,7 +565,7 @@ impl<'a, W: 'a + Write + Seek, T: ColorType> ImageEncoder<'a, W, T> {
         encoder.write_tag(Tag::Compression, 1u16);
 
         encoder.write_tag(Tag::BitsPerSample, <T>::BITS_PER_SAMPLE);
-        encoder.write_tag(Tag::PhotometricInterpretation, <T>::TIFF_VALUE as u16);
+        encoder.write_tag(Tag::PhotometricInterpretation, <T>::TIFF_VALUE.to_u16());
 
         encoder.write_tag(Tag::RowsPerStrip, rows_per_strip as u32);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 extern crate byteorder;
 extern crate lzw;
 extern crate miniz_oxide;
-extern crate num_traits;
 
 pub mod decoder;
 pub mod encoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,8 +9,6 @@
 extern crate byteorder;
 extern crate lzw;
 extern crate miniz_oxide;
-#[macro_use]
-extern crate num_derive;
 extern crate num_traits;
 
 pub mod decoder;


### PR DESCRIPTION
This is more flexible and removes the dependency.

Note that `FromPrimitive` was used with only a single primitive type as the source. This not only increases the public interface much more than necessary but is also misleading. All fields that can be converted as such have specified widths iirc.

The `num-derive` crate does also not handle non-exhaustiveness which is a major future compatibility hazard as more tags etc. are to be supported.

Closes: #57, #59 