### PR TITLE
Document changes for release 0.4

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,12 @@
+# Version 0.4.0
+
+* Several enumerations are now non_exhaustive for future extensions.
+  These are `Tag`, `Type`, `Value`, `PhotometricInterpretation`,
+  `CompressionMethod`, `Predictor`.
+* Enums gained a dedicated method to convert to their TIFF variant value with
+  the specified type. Performing these conversions by casting the discriminant
+  with `as` is not guaranteed to be stable, except where documented explicitly.
+* Removed the num-derive and num dependencies.
+* Added support for decoding `deflate` compressed images.
+* Make the decoder `Limits` customizable by exposing members.
+* Fixed multi-page TIFF encoding writing incorrect offsets.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiff"
-version = "0.3.1"
+version = "0.4.0"
 authors = [
     "ccgn",
     "bvssvni <bvssvni@gmail.com>",


### PR DESCRIPTION
When this PR is merged then version 0.4 will be released. This serves as a last comment period since the crate is smaller and thus produces less immediate feedback.

Fixes: #48, #59, #60