### PR TITLE
Read ascii encoded in offset

### DIFF
--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -200,8 +200,8 @@ impl Entry {
                 }
                 if n <= 4 {
                     let mut buf = vec![0; n];
-                    self.r(bo).read_exact(&mut buf ).unwrap();
-                    let v = String::from_utf8(buf).unwrap();
+                    self.r(bo).read_exact(&mut buf )?;
+                    let v = String::from_utf8(buf)?;
                     let v = v.trim_matches(char::from(0));
                     Ok(Ascii(v.into()))
                 } else {

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -198,9 +198,17 @@ impl Entry {
                 if n > limits.decoding_buffer_size {
                     return Err(TiffError::LimitsExceeded);
                 }
-                decoder.goto_offset(self.r(bo).read_u32()?)?;
-                let string = decoder.read_string(n)?;
-                Ok(Ascii(string))
+                if n <= 4 {
+                    let mut buf = vec![0; n];
+                    self.r(bo).read_exact(&mut buf ).unwrap();
+                    let v = String::from_utf8(buf).unwrap();
+                    let v = v.trim_matches(char::from(0));
+                    Ok(Ascii(v.into()))
+                } else {
+                    decoder.goto_offset(self.r(bo).read_u32()?)?;
+                    let string = decoder.read_string(n)?;
+                    Ok(Ascii(string))
+                }
             }
             _ => Err(TiffError::UnsupportedError(
                 TiffUnsupportedError::UnsupportedDataType,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -424,11 +424,13 @@ impl<R: Read + Seek> Decoder<R> {
     /// Reads a string
     #[inline]
     pub fn read_string(&mut self, length: usize) -> TiffResult<String> {
-        let mut out = String::with_capacity(length);
-        self.reader.read_to_string(&mut out)?;
+        let mut out = vec![0; length];
+        self.reader.read_exact(&mut out)?;
         // Strings may be null-terminated, so we trim anything downstream of the null byte
-        let trimmed = out.bytes().take_while(|&n| n != 0).collect::<Vec<u8>>();
-        Ok(String::from_utf8(trimmed)?)
+        if let Some(first) = out.iter().position(|&b| b == 0) {
+            out.truncate(first);
+        }
+        Ok(String::from_utf8(out)?)
     }
 
     /// Reads a TIFF IFA offset/value field


### PR DESCRIPTION
Currently the code try to read ascii encoded at the offset position but if it can be encoded on 4 bytes the tag is encoded in the offset and the code fail. I also fix an issue with the current read_string method.

I have tested this code by decoding geotiff file and in specialy the gdal_no_data tag of this image: https://github.com/georust/geotiff/blob/master/resources/zh_dem_25.tif

```rust
let img_file = File::open("resources/zh_dem_25.tif").expect("Cannot find test image!");
let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
println!("{:#?}", decoder);
let no_data = decoder.get_tag(tiff::tags::Tag::Unknown(42113)).expect("Failed to get tag");
println!("{:?}", no_data);
```