### PR TITLE
Support tile and sample format tags

### DIFF
--- a/src/tags.rs
+++ b/src/tags.rs
@@ -105,6 +105,11 @@ pub enum Tag(u16) unknown("A private or extension tag") {
     YResolution = 283,
     // Advanced tags
     Predictor = 317,
+    TileWidth = 322,
+    TileLength = 323,
+    TileOffsets = 324,
+    TileByteCounts = 325,
+    SampleFormat = 339,
 }
 }
 


### PR DESCRIPTION
Tiff can use strip or tiles to store data. It would be great to add this tags as their are part of the 6.0 spec. Some explanations can be found here: https://www.fileformat.info/format/tiff/egff.htm