### PR TITLE
Export tag macro rule

### DIFF
--- a/src/tags.rs
+++ b/src/tags.rs
@@ -1,3 +1,4 @@
+#[macro_export]
 macro_rules! tags {
     {
         // Permit arbitrary meta items, which include documentation.


### PR DESCRIPTION
I don't know how we are supposed to implement our own tags but this is how i did:

```rust
use tiff::tags;
use tiff::tags::Tag;

tags! {
pub enum GeoTiffTag(u16) {
    // GDAL
    GdalMetadata = 42112,
    GdalNodata = 42113,

    // GeoTiff
    ModelPixelScale = 33550,
    ModelTiepoint = 33922,
    ModelTransformationTag = 34264,
    GeoKeyDirectoryTag =34735,
    GeoDoubleParamsTag= 34736,
    GeoAsciiParamsTag =34737,
}
}

impl From<GeoTiffTag> for Tag {
    fn from(g: GeoTiffTag) -> Self {
        Tag::Unknown(g.to_u16())
    }
}
```

Then i can easily call the decoder with my own tags:
```rust
let no_data = decoder.get_tag(GeoTiffTag::GdalNodata.into()).expect("Failed to get tag");
```

Is there a better way to implement my own tags and use it with the decoder ? 