### PR TITLE
WIP: add encoding with compression, additional tags, float support and bigtiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,5 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 
 [dependencies]
 byteorder = "1.2"
-lzw = "0.10"
+lzw = { git = "https://github.com/Rogach/lzw" }
 miniz_oxide = "0.3"

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -9,14 +9,15 @@ use super::stream::{ByteOrder, EndianReader, SmartReader};
 use tags::{Tag, Type};
 use {TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
-use self::Value::{Ascii, List, Rational, Unsigned, Signed, SRational};
-
+use self::Value::{Ascii, List, Rational, SRational, Signed, Unsigned, Float, Double};
 
 #[allow(unused_qualifications)]
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Value {
     Signed(i32),
     Unsigned(u32),
+    Float(f32),
+    Double(f64),
     List(Vec<Value>),
     Rational(u32, u32),
     SRational(i32, i32),
@@ -40,6 +41,24 @@ impl Value {
             Signed(val) => Ok(val),
             val => Err(TiffError::FormatError(
                 TiffFormatError::SignedIntegerExpected(val),
+            )),
+        }
+    }
+
+    pub fn into_f32(self) -> TiffResult<f32> {
+        match self {
+            Float(val) => Ok(val),
+            val => Err(TiffError::FormatError(
+                TiffFormatError::FloatExpected(val),
+            )),
+        }
+    }
+
+    pub fn into_f64(self) -> TiffResult<f64> {
+        match self {
+            Double(val) => Ok(val),
+            val => Err(TiffError::FormatError(
+                TiffFormatError::DoubleExpected(val),
             )),
         }
     }
@@ -72,7 +91,7 @@ impl Value {
                             new_vec.push(numerator);
                             new_vec.push(denominator);
                         }
-                        _ => new_vec.push(v.into_i32()?)
+                        _ => new_vec.push(v.into_i32()?),
                     }
                 }
                 Ok(new_vec)
@@ -81,6 +100,38 @@ impl Value {
             SRational(numerator, denominator) => Ok(vec![numerator, denominator]),
             val => Err(TiffError::FormatError(
                 TiffFormatError::SignedIntegerExpected(val),
+            )),
+        }
+    }
+
+    pub fn into_f32_vec(self) -> TiffResult<Vec<f32>> {
+        match self {
+            List(vec) => {
+                let mut new_vec = Vec::with_capacity(vec.len());
+                for v in vec {
+                    new_vec.push(v.into_f32()?)
+                }
+                Ok(new_vec)
+            },
+            Float(val) => Ok(vec![val]),
+            val => Err(TiffError::FormatError(
+                TiffFormatError::UnsignedIntegerExpected(val),
+            )),
+        }
+    }
+
+    pub fn into_f64_vec(self) -> TiffResult<Vec<f64>> {
+        match self {
+            List(vec) => {
+                let mut new_vec = Vec::with_capacity(vec.len());
+                for v in vec {
+                    new_vec.push(v.into_f64()?)
+                }
+                Ok(new_vec)
+            }
+            Double(val) => Ok(vec![val]),
+            val => Err(TiffError::FormatError(
+                TiffFormatError::UnsignedIntegerExpected(val),
             )),
         }
     }
@@ -169,6 +220,12 @@ impl Entry {
             (Type::SLONG, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
                 Ok(Signed(decoder.read_slong()?))
             }),
+            (Type::FLOAT, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
+                Ok(Float(decoder.read_float()?))
+            }),
+            (Type::DOUBLE, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
+                Ok(Double(decoder.read_double()?))
+            }),
             (Type::RATIONAL, 1) => {
                 decoder.goto_offset(self.r(bo).read_u32()?)?;
                 let numerator = decoder.read_long()?;
@@ -182,16 +239,10 @@ impl Entry {
                 Ok(SRational(numerator, denominator))
             }
             (Type::RATIONAL, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
-                Ok(Rational(
-                    decoder.read_long()?,
-                    decoder.read_long()?,
-                ))
+                Ok(Rational(decoder.read_long()?, decoder.read_long()?))
             }),
             (Type::SRATIONAL, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
-                Ok(SRational(
-                    decoder.read_slong()?,
-                    decoder.read_slong()?,
-                ))
+                Ok(SRational(decoder.read_slong()?, decoder.read_slong()?))
             }),
             (Type::ASCII, n) => {
                 let n = usize::try_from(n)?;
@@ -209,10 +260,17 @@ impl Entry {
     }
 
     #[inline]
-    fn decode_offset<R, F>(&self, value_count: u32, bo: ByteOrder, limits: &super::Limits, decoder: &mut super::Decoder<R>, decode_fn: F) -> TiffResult<Value>
-        where
-            R: Read + Seek,
-            F: Fn(&mut super::Decoder<R>) -> TiffResult<Value>,
+    fn decode_offset<R, F>(
+        &self,
+        value_count: u32,
+        bo: ByteOrder,
+        limits: &super::Limits,
+        decoder: &mut super::Decoder<R>,
+        decode_fn: F,
+    ) -> TiffResult<Value>
+    where
+        R: Read + Seek,
+        F: Fn(&mut super::Decoder<R>) -> TiffResult<Value>,
     {
         let value_count = usize::try_from(value_count)?;
         if value_count > limits.decoding_buffer_size / mem::size_of::<Value>() {
@@ -235,7 +293,7 @@ fn offset_to_bytes(n: usize, entry: &Entry) -> TiffResult<Value> {
         entry.offset[0..n]
             .iter()
             .map(|&e| Unsigned(u32::from(e)))
-            .collect()
+            .collect(),
     ))
 }
 
@@ -246,7 +304,7 @@ fn offset_to_sbytes(n: usize, entry: &Entry) -> TiffResult<Value> {
         entry.offset[0..n]
             .iter()
             .map(|&e| Signed(i32::from(e as i8)))
-            .collect()
+            .collect(),
     ))
 }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -421,6 +421,18 @@ impl<R: Read + Seek> Decoder<R> {
         self.reader.read_i32()
     }
 
+    /// Reads a TIFF float valu
+    #[inline]
+    pub fn read_float(&mut self) -> Result<f32, io::Error> {
+        self.reader.read_f32()
+    }
+
+     /// Reads a TIFF double value
+    #[inline]
+    pub fn read_double(&mut self) -> Result<f64, io::Error> {
+        self.reader.read_f64()
+    }
+
     /// Reads a string
     #[inline]
     pub fn read_string(&mut self, length: usize) -> TiffResult<String> {
@@ -572,7 +584,7 @@ impl<R: Read + Seek> Decoder<R> {
     ) -> TiffResult<usize> {
         let color_type = self.colortype()?;
         self.goto_offset(offset)?;
-        let (bytes, mut reader): (usize, Box<EndianReader>) = match self.compression_method {
+        let (bytes, mut reader): (usize, Box<dyn EndianReader>) = match self.compression_method {
             CompressionMethod::None => {
                 let order = self.reader.byte_order;
                 (

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -100,6 +100,24 @@ pub trait EndianReader: Read {
             ByteOrder::BigEndian => <Self as ReadBytesExt>::read_i32::<BigEndian>(self),
         }
     }
+
+    /// Reads an f32
+    #[inline(always)]
+    fn read_f32(&mut self) -> Result<f32, io::Error> {
+        match self.byte_order() {
+            ByteOrder::LittleEndian => <Self as ReadBytesExt>::read_f32::<LittleEndian>(self),
+            ByteOrder::BigEndian => <Self as ReadBytesExt>::read_f32::<BigEndian>(self),
+        }
+    }
+
+    /// Reads an f64
+    #[inline(always)]
+    fn read_f64(&mut self) -> Result<f64, io::Error> {
+        match self.byte_order() {
+            ByteOrder::LittleEndian => <Self as ReadBytesExt>::read_f64::<LittleEndian>(self),
+            ByteOrder::BigEndian => <Self as ReadBytesExt>::read_f64::<BigEndian>(self),
+        }
+    }
 }
 
 /// Reader that decompresses DEFLATE streams

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -1,123 +1,117 @@
+use super::Value;
 use tags::PhotometricInterpretation;
 
-/// Trait for different colortypes that can be encoded.
-pub trait ColorType {
-    /// The type of each sample of this colortype
-    type Inner: super::TiffValue;
-    /// The value of the tiff tag `PhotometricInterpretation`
-    const TIFF_VALUE: PhotometricInterpretation;
-    /// The value of the tiff tag `BitsPerSample`
-    const BITS_PER_SAMPLE: &'static [u16];
+pub struct ColorType {
+    pub value: Value,
+    pub tiff_value: PhotometricInterpretation,
+    pub bit_per_sample: &'static [u16],
 }
 
-pub struct Gray8;
-impl ColorType for Gray8 {
-    type Inner = u8;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
-    const BITS_PER_SAMPLE: &'static [u16] = &[8];
-}
+pub const GRAY8: ColorType = ColorType {
+    value: Value::U8(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[8],
+};
+pub const GRAYI8: ColorType = ColorType {
+    value: Value::I8(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[8],
+};
+pub const GRAY16: ColorType = ColorType {
+    value: Value::U16(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[16],
+};
+pub const GRAYI16: ColorType = ColorType {
+    value: Value::I16(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[16],
+};
+pub const GRAY32: ColorType = ColorType {
+    value: Value::U32(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[32],
+};
+pub const GRAYI32: ColorType = ColorType {
+    value: Value::I32(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[32],
+};
+pub const GRAYF32: ColorType = ColorType {
+    value: Value::F32(0_f32),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[32],
+};
+pub const GRAY64: ColorType = ColorType {
+    value: Value::U64(0),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[64],
+};
+pub const GRAYF64: ColorType = ColorType {
+    value: Value::F64(0_f64),
+    tiff_value: PhotometricInterpretation::BlackIsZero,
+    bit_per_sample: &[64],
+};
 
-pub struct Gray16;
-impl ColorType for Gray16 {
-    type Inner = u16;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
-    const BITS_PER_SAMPLE: &'static [u16] = &[16];
-}
+pub const RGB8: ColorType = ColorType {
+    value: Value::U8(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[8, 8, 8],
+};
+pub const RGB16: ColorType = ColorType {
+    value: Value::U16(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[16, 16, 16],
+};
+pub const RGB32: ColorType = ColorType {
+    value: Value::U32(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[32, 32, 32],
+};
+pub const RGB64: ColorType = ColorType {
+    value: Value::U64(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[64, 64, 64],
+};
 
-pub struct Gray32;
-impl ColorType for Gray32 {
-    type Inner = u32;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
-    const BITS_PER_SAMPLE: &'static [u16] = &[32];
-}
+pub const RGBA8: ColorType = ColorType {
+    value: Value::U8(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[8, 8, 8, 8],
+};
+pub const RGBA16: ColorType = ColorType {
+    value: Value::U16(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[16, 16, 16, 16],
+};
+pub const RGBA32: ColorType = ColorType {
+    value: Value::U32(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[32, 32, 32, 32],
+};
+pub const RGBA64: ColorType = ColorType {
+    value: Value::U64(0),
+    tiff_value: PhotometricInterpretation::RGB,
+    bit_per_sample: &[64, 64, 64, 64],
+};
 
-pub struct Gray64;
-impl ColorType for Gray64 {
-    type Inner = u64;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::BlackIsZero;
-    const BITS_PER_SAMPLE: &'static [u16] = &[64];
-}
-
-pub struct RGB8;
-impl ColorType for RGB8 {
-    type Inner = u8;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8];
-}
-
-pub struct RGB16;
-impl ColorType for RGB16 {
-    type Inner = u16;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16];
-}
-
-pub struct RGB32;
-impl ColorType for RGB32 {
-    type Inner = u32;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32];
-}
-
-pub struct RGB64;
-impl ColorType for RGB64 {
-    type Inner = u64;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64];
-}
-
-pub struct RGBA8;
-impl ColorType for RGBA8 {
-    type Inner = u8;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8, 8];
-}
-
-pub struct RGBA16;
-impl ColorType for RGBA16 {
-    type Inner = u16;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16, 16];
-}
-
-pub struct RGBA32;
-impl ColorType for RGBA32 {
-    type Inner = u16;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32, 32];
-}
-
-pub struct RGBA64;
-impl ColorType for RGBA64 {
-    type Inner = u16;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::RGB;
-    const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64, 64];
-}
-
-pub struct CMYK8;
-impl ColorType for CMYK8 {
-    type Inner = u8;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::CMYK;
-    const BITS_PER_SAMPLE: &'static [u16] = &[8, 8, 8, 8];
-}
-
-pub struct CMYK16;
-impl ColorType for CMYK16 {
-    type Inner = u16;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::CMYK;
-    const BITS_PER_SAMPLE: &'static [u16] = &[16, 16, 16, 16];
-}
-
-pub struct CMYK32;
-impl ColorType for CMYK32 {
-    type Inner = u32;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::CMYK;
-    const BITS_PER_SAMPLE: &'static [u16] = &[32, 32, 32, 32];
-}
-
-pub struct CMYK64;
-impl ColorType for CMYK64 {
-    type Inner = u64;
-    const TIFF_VALUE: PhotometricInterpretation = PhotometricInterpretation::CMYK;
-    const BITS_PER_SAMPLE: &'static [u16] = &[64, 64, 64, 64];
-}
+pub const CMYK8: ColorType = ColorType {
+    value: Value::U8(0),
+    tiff_value: PhotometricInterpretation::CMYK,
+    bit_per_sample: &[8, 8, 8, 8],
+};
+pub const CMYK16: ColorType = ColorType {
+    value: Value::U16(0),
+    tiff_value: PhotometricInterpretation::CMYK,
+    bit_per_sample: &[16, 16, 16, 16],
+};
+pub const CMYK32: ColorType = ColorType {
+    value: Value::U32(0),
+    tiff_value: PhotometricInterpretation::CMYK,
+    bit_per_sample: &[32, 32, 32, 32],
+};
+pub const CMYK64: ColorType = ColorType {
+    value: Value::U64(0),
+    tiff_value: PhotometricInterpretation::CMYK,
+    bit_per_sample: &[64, 64, 64, 64],
+};

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -86,12 +86,27 @@ impl<W: Write> TiffWriter<W> {
         Ok(())
     }
 
+    pub fn write_f32(&mut self, n: f32) -> Result<(), io::Error> {
+        self.writer.write_f32::<NativeEndian>(n)?;
+        self.offset += 4;
+
+        Ok(())
+    }
+    
     pub fn write_u64(&mut self, n: u64) -> Result<(), io::Error> {
         self.writer.write_u64::<NativeEndian>(n)?;
         self.offset += 8;
 
         Ok(())
     }
+    
+    pub fn write_f64(&mut self, n: f64) -> Result<(), io::Error> {
+        self.writer.write_f64::<NativeEndian>(n)?;
+        self.offset += 8;
+
+        Ok(())
+    }
+    
 
     pub fn pad_word_boundary(&mut self) -> Result<(), io::Error> {
         if self.offset % 4 != 0 {

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -27,7 +27,7 @@ impl TiffByteOrder for BigEndian {
 }
 
 pub struct TiffWriter<W> {
-    writer: W,
+    pub writer: W,
     offset: u64,
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -35,7 +35,7 @@ pub enum TiffError {
 ///
 /// The list of variants may grow to incorporate errors of future features. Matching against this
 /// exhaustively is not covered by interface stability guarantees.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TiffFormatError {
     TiffSignatureNotFound,
     TiffSignatureInvalid,
@@ -47,6 +47,8 @@ pub enum TiffFormatError {
     UnknownPredictor(u16),
     UnsignedIntegerExpected(Value),
     SignedIntegerExpected(Value),
+    FloatExpected(Value),
+    DoubleExpected(Value),
     InflateError(InflateError),
     #[doc(hidden)]
     /// Do not match against this variant. It may get removed.
@@ -73,6 +75,12 @@ impl fmt::Display for TiffFormatError {
             }
             SignedIntegerExpected(ref val) => {
                 write!(fmt, "Expected signed integer, {:?} found.", val)
+            }
+            FloatExpected(ref val) => {
+                write!(fmt, "Expected float, {:?} found.", val)
+            }
+            DoubleExpected(ref val) => {
+                write!(fmt, "Expected double, {:?} found.", val)
             }
             InflateError(_) => write!(fmt, "Failed to decode inflate data."),
             __NonExhaustive => unreachable!(),

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -126,6 +126,8 @@ pub enum Type(u16) {
     SSHORT = 8,
     SLONG = 9,
     SRATIONAL = 10,
+    FLOAT = 11,
+    DOUBLE = 12,
     /// BigTIFF 64-bit unsigned integer
     LONG8 = 16,
 }

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -1,7 +1,7 @@
 extern crate tiff;
 
-use tiff::decoder::{Decoder, DecodingResult};
-use tiff::encoder::{colortype, TiffEncoder, SRational};
+use tiff::decoder::{ifd, Decoder, DecodingResult};
+use tiff::encoder::{colortype, TiffEncoder, SRational, Value};
 use tiff::ColorType;
 use tiff::tags::{Tag, CompressionMethod};
 
@@ -24,7 +24,7 @@ fn encode_decode() {
     {
         let mut tiff = TiffEncoder::new(&mut file).unwrap();
 
-        tiff.write_image::<colortype::RGB8>(100, 100, &image_data, CompressionMethod::None, vec![])
+        tiff.write_image(100, 100, &Value::from(&image_data[..]), colortype::RGB8, CompressionMethod::None, vec![(Tag::Artist, Value::Str("Image-tiff".into()))])
             .unwrap();
     }
     {
@@ -32,6 +32,7 @@ fn encode_decode() {
         let mut decoder = Decoder::new(&mut file).unwrap();
         assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
         assert_eq!(decoder.dimensions().unwrap(), (100, 100));
+        assert_eq!(decoder.get_tag(Tag::Artist).unwrap(), ifd::Value::Ascii("Image-tiff".into()));
         if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
             assert_eq!(image_data, img_res);
         } else {
@@ -49,7 +50,7 @@ fn test_encode_undersized_buffer() {
     let output = Vec::new();
     let mut output_stream = Cursor::new(output);
     if let Ok(mut tiff) = TiffEncoder::new(&mut output_stream) {
-        let res = tiff.write_image::<colortype::RGB8>(50, 50, &input_data, CompressionMethod::None, vec![]);
+        let res = tiff.write_image(50, 50, &Value::AI32(input_data), colortype::RGB8, CompressionMethod::None, vec![]);
         assert!(res.is_err());
     }
 }
@@ -57,8 +58,8 @@ fn test_encode_undersized_buffer() {
 const TEST_IMAGE_DIR: &str = "./tests/images/";
 
 macro_rules! test_roundtrip {
-    ($name:ident, $buffer:ident, $buffer_ty:ty) => {
-        fn $name<C: colortype::ColorType<Inner=$buffer_ty>>(file: &str, expected_type: ColorType) {
+    ($name:ident, $buffer:ident) => {
+        fn $name(colortype: colortype::ColorType, file: &str, expected_type: ColorType) {
             let path = PathBuf::from(TEST_IMAGE_DIR).join(file);
             let img_file = File::open(path).expect("Cannot find test image!");
             let mut decoder = Decoder::new(img_file).expect("Cannot create decoder");
@@ -74,7 +75,7 @@ macro_rules! test_roundtrip {
                 let mut tiff = TiffEncoder::new(&mut file).unwrap();
 
                 let (width, height) = decoder.dimensions().unwrap();
-                tiff.write_image::<C>(width, height, &image_data, CompressionMethod::None, vec![])
+                tiff.write_image(width, height, &Value::from(&image_data[..]), colortype, CompressionMethod::None, vec![])
                     .unwrap();
             }
             file.seek(SeekFrom::Start(0)).unwrap();
@@ -90,59 +91,59 @@ macro_rules! test_roundtrip {
     };
 }
 
-test_roundtrip!(test_u8_roundtrip, U8, u8);
-test_roundtrip!(test_u16_roundtrip, U16, u16);
-test_roundtrip!(test_u32_roundtrip, U32, u32);
-test_roundtrip!(test_u64_roundtrip, U64, u64);
+test_roundtrip!(test_u8_roundtrip, U8);
+test_roundtrip!(test_u16_roundtrip, U16);
+test_roundtrip!(test_u32_roundtrip, U32);
+test_roundtrip!(test_u64_roundtrip, U64);
 
 #[test]
 fn test_gray_u8_roundtrip() {
-    test_u8_roundtrip::<colortype::Gray8>("minisblack-1c-8b.tiff", ColorType::Gray(8));
+    test_u8_roundtrip(colortype::GRAY8, "minisblack-1c-8b.tiff", ColorType::Gray(8));
 }
 
 #[test]
 fn test_rgb_u8_roundtrip() {
-    test_u8_roundtrip::<colortype::RGB8>("rgb-3c-8b.tiff", ColorType::RGB(8));
+    test_u8_roundtrip(colortype::RGB8, "rgb-3c-8b.tiff", ColorType::RGB(8));
 }
 
 #[test]
 fn test_cmyk_u8_roundtrip() {
-    test_u8_roundtrip::<colortype::CMYK8>("cmyk-3c-8b.tiff", ColorType::CMYK(8));
+    test_u8_roundtrip(colortype::CMYK8, "cmyk-3c-8b.tiff", ColorType::CMYK(8));
 }
 
 #[test]
 fn test_gray_u16_roundtrip() {
-    test_u16_roundtrip::<colortype::Gray16>("minisblack-1c-16b.tiff", ColorType::Gray(16));
+    test_u16_roundtrip(colortype::GRAY16, "minisblack-1c-16b.tiff", ColorType::Gray(16));
 }
 
 #[test]
 fn test_rgb_u16_roundtrip() {
-    test_u16_roundtrip::<colortype::RGB16>("rgb-3c-16b.tiff", ColorType::RGB(16));
+    test_u16_roundtrip(colortype::RGB16, "rgb-3c-16b.tiff", ColorType::RGB(16));
 }
 
 #[test]
 fn test_cmyk_u16_roundtrip() {
-    test_u16_roundtrip::<colortype::CMYK16>("cmyk-3c-16b.tiff", ColorType::CMYK(16));
+    test_u16_roundtrip(colortype::CMYK16, "cmyk-3c-16b.tiff", ColorType::CMYK(16));
 }
 
 #[test]
 fn test_gray_u32_roundtrip() {
-    test_u32_roundtrip::<colortype::Gray32>("gradient-1c-32b.tiff", ColorType::Gray(32));
+    test_u32_roundtrip(colortype::GRAY32, "gradient-1c-32b.tiff", ColorType::Gray(32));
 }
 
 #[test]
 fn test_rgb_u32_roundtrip() {
-    test_u32_roundtrip::<colortype::RGB32>("gradient-3c-32b.tiff", ColorType::RGB(32));
+    test_u32_roundtrip(colortype::RGB32, "gradient-3c-32b.tiff", ColorType::RGB(32));
 }
 
 #[test]
 fn test_gray_u64_roundtrip() {
-    test_u64_roundtrip::<colortype::Gray64>("gradient-1c-64b.tiff", ColorType::Gray(64));
+    test_u64_roundtrip(colortype::GRAY64, "gradient-1c-64b.tiff", ColorType::Gray(64));
 }
 
 #[test]
 fn test_rgb_u64_roundtrip() {
-    test_u64_roundtrip::<colortype::RGB64>("gradient-3c-64b.tiff", ColorType::RGB(64));
+    test_u64_roundtrip(colortype::RGB64, "gradient-3c-64b.tiff", ColorType::RGB(64));
 }
 
 #[test]
@@ -151,14 +152,14 @@ fn test_multiple_byte() {
 
     {
         let mut tiff = TiffEncoder::new(&mut data).unwrap();
-        let mut image_encoder = tiff.new_image::<colortype::Gray8>(1, 1, CompressionMethod::None, vec![]).unwrap();
+        let mut image_encoder = tiff.new_image(1, 1, colortype::GRAY8, CompressionMethod::None, vec![]).unwrap();
         let encoder = image_encoder.encoder();
 
-        encoder.write_tag(Tag::Unknown(65000), &[1_u8][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65001), &[1_u8, 2][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65002), &[1_u8, 2, 3][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65003), &[1_u8, 2, 3, 4][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65004), &[1_u8, 2, 3, 4, 5][..]).unwrap();
+        encoder.write_tag(Tag::Unknown(65000), Value::from(&[1_u8][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65001), Value::from(&[1_u8, 2][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65002), Value::from(&[1_u8, 2, 3][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65003), Value::from(&[1_u8, 2, 3, 4][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65004), Value::from(&[1_u8, 2, 3, 4, 5][..])).unwrap();
     }
 
     data.set_position(0);
@@ -180,28 +181,28 @@ fn test_signed() {
 
     {
         let mut tiff = TiffEncoder::new(&mut data).unwrap();
-        let mut image_encoder = tiff.new_image::<colortype::Gray8>(1, 1, CompressionMethod::None, vec![]).unwrap();
+        let mut image_encoder = tiff.new_image(1, 1, colortype::GRAY8, CompressionMethod::None, vec![]).unwrap();
         let encoder = image_encoder.encoder();
 
         //Use the "reusable" tags section as per the TIFF6 spec
-        encoder.write_tag(Tag::Unknown(65000), -1_i8).unwrap();
-        encoder.write_tag(Tag::Unknown(65001), &[-1_i8][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65002), &[-1_i8, 2][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65003), &[-1_i8, 2, -3][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65004), &[-1_i8, 2, -3, 4][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65005), &[-1_i8, 2, -3, 4, -5][..]).unwrap();
+        encoder.write_tag(Tag::Unknown(65000), Value::from(-1_i8)).unwrap();
+        encoder.write_tag(Tag::Unknown(65001), Value::from(&[-1_i8][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65002), Value::from(&[-1_i8, 2][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65003), Value::from(&[-1_i8, 2, -3][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65004), Value::from(&[-1_i8, 2, -3, 4][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65005), Value::from(&[-1_i8, 2, -3, 4, -5][..])).unwrap();
 
-        encoder.write_tag(Tag::Unknown(65010), -1_i16).unwrap();
-        encoder.write_tag(Tag::Unknown(65011), -1_i16).unwrap();
-        encoder.write_tag(Tag::Unknown(65012), &[-1_i16, 2][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65013), &[-1_i16, 2, -3][..]).unwrap();
+        encoder.write_tag(Tag::Unknown(65010), Value::from(-1_i16)).unwrap();
+        encoder.write_tag(Tag::Unknown(65011), Value::from(-1_i16)).unwrap();
+        encoder.write_tag(Tag::Unknown(65012), Value::from(&[-1_i16, 2][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65013), Value::from(&[-1_i16, 2, -3][..])).unwrap();
 
-        encoder.write_tag(Tag::Unknown(65020), -1_i32).unwrap();
-        encoder.write_tag(Tag::Unknown(65021), &[-1_i32][..]).unwrap();
-        encoder.write_tag(Tag::Unknown(65022), &[-1_i32, 2][..]).unwrap();
+        encoder.write_tag(Tag::Unknown(65020), Value::from(-1_i32)).unwrap();
+        encoder.write_tag(Tag::Unknown(65021), Value::from(&[-1_i32][..])).unwrap();
+        encoder.write_tag(Tag::Unknown(65022), Value::from(&[-1_i32, 2][..])).unwrap();
 
-        encoder.write_tag(Tag::Unknown(65030), SRational { n: -1, d: 100 }).unwrap();
-        encoder.write_tag(Tag::Unknown(65031), &[SRational { n: -1, d: 100 }, SRational { n: 2, d: 100 }][..]).unwrap();
+        encoder.write_tag(Tag::Unknown(65030), Value::from(SRational { n: -1, d: 100 })).unwrap();
+        encoder.write_tag(Tag::Unknown(65031), Value::from(&[SRational { n: -1, d: 100 }, SRational { n: 2, d: 100 }][..])).unwrap();
     }
 
     //Rewind the cursor for reading
@@ -241,10 +242,10 @@ fn test_multipage_image() {
 
         // write first grayscale image (2x2 16-bit)
         let img1: Vec<u16> = [1, 2, 3, 4].to_vec();
-        img_encoder.write_image::<colortype::Gray16>(2, 2, &img1[..], CompressionMethod::None, vec![]).unwrap();
+        img_encoder.write_image(2, 2, &Value::AU16(img1), colortype::GRAY16, CompressionMethod::None, vec![]).unwrap();
         // write second grayscale image (3x3 8-bit)
         let img2: Vec<u8> = [9, 8, 7, 6, 5, 4, 3, 2, 1].to_vec();
-        img_encoder.write_image::<colortype::Gray8>(3, 3, &img2[..], CompressionMethod::None, vec![]).unwrap();
+        img_encoder.write_image(3, 3, &Value::AU8(img2), colortype::GRAY8, CompressionMethod::None, vec![]).unwrap();
     }
 
     // seek to the beginning of the file, so that it can be decoded

--- a/tests/encode_images.rs
+++ b/tests/encode_images.rs
@@ -3,7 +3,7 @@ extern crate tiff;
 use tiff::decoder::{Decoder, DecodingResult};
 use tiff::encoder::{colortype, TiffEncoder, SRational};
 use tiff::ColorType;
-use tiff::tags::Tag;
+use tiff::tags::{Tag, CompressionMethod};
 
 use std::fs::File;
 use std::io::{Cursor, Seek, SeekFrom};
@@ -24,7 +24,7 @@ fn encode_decode() {
     {
         let mut tiff = TiffEncoder::new(&mut file).unwrap();
 
-        tiff.write_image::<colortype::RGB8>(100, 100, &image_data)
+        tiff.write_image::<colortype::RGB8>(100, 100, &image_data, CompressionMethod::None, vec![])
             .unwrap();
     }
     {
@@ -49,7 +49,7 @@ fn test_encode_undersized_buffer() {
     let output = Vec::new();
     let mut output_stream = Cursor::new(output);
     if let Ok(mut tiff) = TiffEncoder::new(&mut output_stream) {
-        let res = tiff.write_image::<colortype::RGB8>(50, 50, &input_data);
+        let res = tiff.write_image::<colortype::RGB8>(50, 50, &input_data, CompressionMethod::None, vec![]);
         assert!(res.is_err());
     }
 }
@@ -74,7 +74,7 @@ macro_rules! test_roundtrip {
                 let mut tiff = TiffEncoder::new(&mut file).unwrap();
 
                 let (width, height) = decoder.dimensions().unwrap();
-                tiff.write_image::<C>(width, height, &image_data)
+                tiff.write_image::<C>(width, height, &image_data, CompressionMethod::None, vec![])
                     .unwrap();
             }
             file.seek(SeekFrom::Start(0)).unwrap();
@@ -151,7 +151,7 @@ fn test_multiple_byte() {
 
     {
         let mut tiff = TiffEncoder::new(&mut data).unwrap();
-        let mut image_encoder = tiff.new_image::<colortype::Gray8>(1, 1).unwrap();
+        let mut image_encoder = tiff.new_image::<colortype::Gray8>(1, 1, CompressionMethod::None, vec![]).unwrap();
         let encoder = image_encoder.encoder();
 
         encoder.write_tag(Tag::Unknown(65000), &[1_u8][..]).unwrap();
@@ -180,7 +180,7 @@ fn test_signed() {
 
     {
         let mut tiff = TiffEncoder::new(&mut data).unwrap();
-        let mut image_encoder = tiff.new_image::<colortype::Gray8>(1, 1).unwrap();
+        let mut image_encoder = tiff.new_image::<colortype::Gray8>(1, 1, CompressionMethod::None, vec![]).unwrap();
         let encoder = image_encoder.encoder();
 
         //Use the "reusable" tags section as per the TIFF6 spec
@@ -241,10 +241,10 @@ fn test_multipage_image() {
 
         // write first grayscale image (2x2 16-bit)
         let img1: Vec<u16> = [1, 2, 3, 4].to_vec();
-        img_encoder.write_image::<colortype::Gray16>(2, 2, &img1[..]).unwrap();
+        img_encoder.write_image::<colortype::Gray16>(2, 2, &img1[..], CompressionMethod::None, vec![]).unwrap();
         // write second grayscale image (3x3 8-bit)
         let img2: Vec<u8> = [9, 8, 7, 6, 5, 4, 3, 2, 1].to_vec();
-        img_encoder.write_image::<colortype::Gray8>(3, 3, &img2[..]).unwrap();
+        img_encoder.write_image::<colortype::Gray8>(3, 3, &img2[..], CompressionMethod::None, vec![]).unwrap();
     }
 
     // seek to the beginning of the file, so that it can be decoded


### PR DESCRIPTION
This is a work in progress and i need some advice about the implementation.

First the lzw lib is unmaintained but there is a fork in image-rs but there is not this pull request merged https://github.com/nwin/lzw/pull/1. To enable the tiff encoding with lzw we need this.

Then I think there is a better way to encode the value to bytes but i didn't find it so i create new `TiffWriter` :/
```rust
        CompressionMethod::LZW => {
                let mut buf = TiffWriter::new(Cursor::new(Vec::new()));
                value.write(&mut buf)?;
                let mut compressed = vec![];
                {
                    let mut lzw_encoder = EncoderTIFF::new(MsbWriter::new(&mut compressed), 8)?;
                    lzw_encoder.encode_bytes(&buf.writer.into_inner()[..])?;
                }
                self.encoder.write_data(&compressed[..])?
        },
```

And the big issue is with the `additional_tags` i can't find a way to allow to pass an array of object implementing the trait `TiffValue` with `Vec<(Tag, Box<dyn TiffValue>)>`, the compiler complain:
```
the trait `encoder::TiffValue` cannot be made into an object
consider moving `write` to another trait
consider moving `BYTE_LEN` to another trait
consider moving `FIELD_TYPE` to another trait rustc(E0038)
mod.rs(38, 8): ...because method `write` has generic type parameters
mod.rs(32, 11): ...because it contains this associated `const`
mod.rs(33, 11): ...because it contains this associated `const`
mod.rs(31, 11): this trait cannot be made into an object...
```
So currently you can only use one type of TiffValue and need to specify it when you write the image or create the encoder like the colortype :cry: 