### PR TITLE
Update release notes for alpha release for BigTIFF

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+# Version 0.6.0-alpha
+
+* Support for decoding BigTIFF with 64-bit offsets
+* Better support for adding auxiliary tags before encoding image data
+* Fixed decoding of inline ASCII in tags
+* Fixed handling after null terminator in ASCII data
+* Recognize tile and sample format tags
+* Note: these notes will be merged into 0.6.0 when it is released
+
 # Version 0.5.0
 
 * Added support for 32-bit and 64-bit decoded values.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiff"
-version = "0.5.0"
+version = "0.6.0-alpha"
 authors = [
     "ccgn",
     "bvssvni <bvssvni@gmail.com>",


### PR DESCRIPTION
As dicussed in #70 it would be good to do these two breaking changes in one major release so let's do an alpha release to make at least BigTIFF usable. Maybe this also shows a few pain points we need to fix, it is afterall a somewhat large extension.