### PR TITLE
Switch to Github Actions for CI checks

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,25 @@
+name: Rust CI
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust: ["1.34.2", stable, beta, nightly]
+        command: [build, test]
+    steps:
+    - uses: actions/checkout@v2
+    - run: rustup default ${{ matrix.rust }}
+    - name: build
+      run: >
+        cargo build --verbose --no-default-features --features "$FEATURES"
+    - name: test
+      run: >
+        cargo test --tests --benches --no-default-features --features "$FEATURES"
+      if: ${{ matrix.rust != '1.34.2' }}
+      env:
+        FEATURES: ${{ matrix.features }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: rust
-rust:
-    - 1.34.2
-    - stable
-    - beta
-    - nightly


### PR DESCRIPTION
More customizable, faster, more integration. We already did that for a
number of other crates with good outcome.