### PR TITLE
Support decoding of modern JPEG compression

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 
 [dependencies]
 weezl = "0.1.0"
+jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false }
 
 [dependencies.miniz_oxide]
 version = "0.4.1"

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -10,8 +10,8 @@ use tags::{Tag, Type};
 use {TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
 use self::Value::{
-    Ascii, Byte, Double, Float, List, Rational, RationalBig, SRational, SRationalBig, Signed, SignedBig,
-    Unsigned, UnsignedBig,
+    Ascii, Byte, Double, Float, List, Rational, RationalBig, SRational, SRationalBig, Signed,
+    SignedBig, Unsigned, UnsignedBig,
 };
 
 #[allow(unused_qualifications)]
@@ -38,9 +38,7 @@ impl Value {
     pub fn into_u8(self) -> TiffResult<u8> {
         match self {
             Byte(val) => Ok(val),
-            val => Err(TiffError::FormatError(
-                TiffFormatError::ByteExpected(val),
-            )),
+            val => Err(TiffError::FormatError(TiffFormatError::ByteExpected(val))),
         }
     }
 
@@ -452,7 +450,7 @@ impl Entry {
                         let string = decoder.read_string(n)?;
                         Ok(Ascii(string))
                     }
-                },
+                }
                 (Type::UNDEFINED, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
                     Ok(Byte(u8::from(decoder.read_byte()?)))
                 }),

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -425,7 +425,10 @@ impl Entry {
                         let string = decoder.read_string(n)?;
                         Ok(Ascii(string))
                     }
-                }
+                },
+                (Type::UNDEFINED, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
+                    Ok(Unsigned(u32::from(decoder.read_byte()?)))
+                }),
                 _ => Err(TiffError::UnsupportedError(
                     TiffUnsupportedError::UnsupportedDataType,
                 )),

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -35,7 +35,6 @@ pub enum Value {
 }
 
 impl Value {
-
     pub fn into_u8(self) -> TiffResult<u8> {
         match self {
             Byte(val) => Ok(val),

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -39,7 +39,7 @@ impl Value {
         match self {
             Byte(val) => Ok(val),
             val => Err(TiffError::FormatError(
-                TiffFormatError::UnsignedIntegerExpected(val),
+                TiffFormatError::ByteExpected(val),
             )),
         }
     }
@@ -454,7 +454,7 @@ impl Entry {
                     }
                 },
                 (Type::UNDEFINED, n) => self.decode_offset(n, bo, limits, decoder, |decoder| {
-                    Ok(Unsigned(u32::from(decoder.read_byte()?)))
+                    Ok(Byte(u8::from(decoder.read_byte()?)))
                 }),
                 _ => Err(TiffError::UnsupportedError(
                     TiffUnsupportedError::UnsupportedDataType,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -950,9 +950,9 @@ impl<R: Read + Seek> Decoder<R> {
             )));
         }
         if offsets.len() != bytes.len() {
-            return Err(TiffError::FormatError(TiffFormatError::Format(
-                String::from("Size mismatch of StripOffsets and StripByteCounts"),
-            )));
+            return Err(TiffError::FormatError(
+                TiffFormatError::InconsistentSizesEncountered,
+            ));
         }
 
         let mut res_img = Vec::with_capacity(offsets[0] as usize);

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -11,7 +11,6 @@ use tags::{CompressionMethod, PhotometricInterpretation, Predictor, SampleFormat
 use self::stream::{
     ByteOrder, DeflateReader, EndianReader, LZWReader, PackBitsReader, SmartReader, JpegReader
 };
-use tags::{CompressionMethod, PhotometricInterpretation, Predictor, Tag, Type};
 
 pub mod ifd;
 mod stream;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -958,7 +958,6 @@ impl<R: Read + Seek> Decoder<R> {
         let mut res_img = Vec::with_capacity(offsets[0] as usize);
 
         for (idx, offset) in offsets.iter().enumerate() {
-
             if bytes[idx] as usize > self.limits.intermediate_buffer_size {
                 return Err(TiffError::LimitsExceeded);
             }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -746,6 +746,11 @@ impl<R: Read + Seek> Decoder<R> {
         self.get_tag(tag)?.into_f64_vec()
     }
 
+    /// Tries to retrieve a tag and convert it to a 8bit vector.
+    pub fn get_tag_u8_vec(&mut self, tag: Tag) -> TiffResult<Vec<u8>> {
+        self.get_tag(tag)?.into_u8_vec()
+    }
+
     /// Decompresses the strip into the supplied buffer.
     /// Returns the number of bytes read.
     fn expand_strip<'a>(

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -712,32 +712,6 @@ impl<R: Read + Seek> Decoder<R> {
         }
     }
 
-    pub fn get_all_tags(&mut self) -> Vec<(Tag, ifd::Value)> {
-        let mut all_tags = Vec::new();
-
-        let dir = match &self.ifd {
-            Some(d) => d,
-            None => {
-                println!("No tags found");
-                return all_tags;
-            }
-        };
-        let keys = dir.keys().cloned().collect::<Vec<Tag>>();
-        // go through all tags
-        for key in keys {
-            let tag_value = match self.get_tag(key) {
-                Ok(val) => val,
-                _ => {
-                    println!("Could not unwrap {:?}", key);
-                    continue;
-                }
-            };
-            all_tags.push((key, tag_value));
-        }
-
-        all_tags
-    }
-
     /// Tries to retrieve a tag and convert it to the desired type.
     pub fn get_tag_u32(&mut self, tag: Tag) -> TiffResult<u32> {
         self.get_tag(tag)?.into_u32()

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -933,7 +933,12 @@ impl<R: Read + Seek> Decoder<R> {
     pub fn read_jpeg(&mut self) -> TiffResult<DecodingResult> {
         let offsets = self.get_tag_u32_vec(Tag::StripOffsets)?;
         let bytes = self.get_tag_u32_vec(Tag::StripByteCounts)?;
-        let jpeg_tables: Vec<u8> = self.get_tag_u8_vec(Tag::JPEGTables)?;
+
+        let jpeg_tables: Option<Vec<u8>> = match self.find_tag(Tag::JPEGTables) {
+            Ok(None) => None,
+            Ok(_) => Some(self.get_tag_u8_vec(Tag::JPEGTables)?),
+            Err(e) => return Err(e),
+        };
 
         if offsets.len() == 0 {
             return Err(TiffError::FormatError(TiffFormatError::RequiredTagEmpty(

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -356,7 +356,8 @@ impl JpegReader {
         match jpeg_tables {
             Some(tables) => {
                 let mut jpeg_data = tables.clone();
-                jpeg_data.truncate(jpeg_data.len() - 2);
+                let truncated_length = jpeg_data.len() - 2;
+                jpeg_data.truncate(truncated_length);
                 jpeg_data.extend_from_slice(&mut segment[2..]);
 
                 Ok(JpegReader {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -187,6 +187,14 @@ pub trait EndianReader: Read {
     }
 }
 
+///
+/// # READERS
+///
+
+///
+/// ## Deflate Reader
+///
+
 /// Reader that decompresses DEFLATE streams
 pub struct DeflateReader {
     buffer: io::Cursor<Vec<u8>>,
@@ -232,6 +240,10 @@ impl EndianReader for DeflateReader {
         self.byte_order
     }
 }
+
+///
+/// ## LZW Reader
+///
 
 /// Reader that decompresses LZW streams
 pub struct LZWReader {
@@ -306,6 +318,76 @@ impl EndianReader for LZWReader {
     }
 }
 
+///
+/// ## JPEG Reader (for "new-style" JPEG format (TIFF compression tag 7))
+///
+
+pub struct JpegReader {
+    buffer: io::Cursor<Vec<u8>>,
+    byte_order: ByteOrder, // for jpeg image data always ...,
+}
+// Only tested with qtables in jpegtables, but it contain both qtables and huffman tables or either
+impl JpegReader {
+    /// Constructs new JpegReader wrapping a SmartReader.
+    /// Because Jpeg compression in TIFF allows to save quantization and/or huffman tables in one
+    /// central loacation, the constructor accepts this data as `jpeg_tables` here containing either
+    /// both.
+    /// These `jpeg_tables` are simply prepended to the remaining jpeg image data.
+    /// Because these jpegtables start with a `SOI` (HEX: `0xFFD8`) or __start of image__ marker
+    /// which is also at the beginning of the remaining jpeg image data and would
+    /// confuse the jpeg renderer, one of these has to be taken off. In this case the first two
+    /// bytes of the remaining jpeg data is removed because this follows `jpeg_tables`.
+    /// Similary, `jpeg_tables` ends with a `EOI` (HEX: `0xFFD9`) or __end of image__ marker,
+    /// this has to be removed as well (last two bytes of `jpeg_tables`).
+
+    pub fn new<R>(
+        reader: &mut SmartReader<R>,
+        length: u32,
+        jpeg_tables: &Vec<u8>
+    ) -> io::Result<JpegReader>
+    where
+        R: Read + Seek,
+    {
+        let order = reader.byte_order;
+
+        // Read jpeg image data
+        let mut segment = vec![0; length as usize];
+        reader.read_exact(&mut segment[..])?;
+
+        let mut jpeg_data = jpeg_tables.clone();
+        jpeg_data.truncate(jpeg_data.len() - 2);
+
+        jpeg_data.extend_from_slice(&mut segment[2..]);
+
+        Ok(
+            JpegReader {
+                buffer: io::Cursor::new(jpeg_data),
+                byte_order: order,
+            },
+        )
+    }
+}
+
+impl Read for JpegReader {
+    // #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.buffer.read(buf)
+    }
+}
+
+impl EndianReader for JpegReader {
+    #[inline(always)]
+    fn byte_order(&self) -> ByteOrder {
+        self.byte_order
+    }
+}
+
+
+
+///
+/// ## PackBits Reader
+///
+
 /// Reader that unpacks Apple's `PackBits` format
 pub struct PackBitsReader {
     buffer: io::Cursor<Vec<u8>>,
@@ -377,6 +459,10 @@ impl EndianReader for PackBitsReader {
         self.byte_order
     }
 }
+
+///
+/// ## SmartReader Reader
+///
 
 /// Reader that is aware of the byte order.
 #[derive(Debug)]

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -322,7 +322,7 @@ impl EndianReader for LZWReader {
 /// ## JPEG Reader (for "new-style" JPEG format (TIFF compression tag 7))
 ///
 
-pub struct JpegReader {
+pub(crate) struct JpegReader {
     buffer: io::Cursor<Vec<u8>>,
     byte_order: ByteOrder, // for jpeg image data always ...,
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -343,7 +343,7 @@ impl JpegReader {
     pub fn new<R>(
         reader: &mut SmartReader<R>,
         length: u32,
-        jpeg_tables: &Vec<u8>
+        jpeg_tables: &Vec<u8>,
     ) -> io::Result<JpegReader>
     where
         R: Read + Seek,
@@ -359,12 +359,10 @@ impl JpegReader {
 
         jpeg_data.extend_from_slice(&mut segment[2..]);
 
-        Ok(
-            JpegReader {
-                buffer: io::Cursor::new(jpeg_data),
-                byte_order: order,
-            },
-        )
+        Ok(JpegReader {
+            buffer: io::Cursor::new(jpeg_data),
+            byte_order: order,
+        })
     }
 }
 
@@ -381,8 +379,6 @@ impl EndianReader for JpegReader {
         self.byte_order
     }
 }
-
-
 
 ///
 /// ## PackBits Reader

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -364,15 +364,12 @@ impl JpegReader {
                     buffer: io::Cursor::new(jpeg_data),
                     byte_order: order,
                 })
-            },
-            None => {
-                Ok(JpegReader {
-                    buffer: io::Cursor::new(segment),
-                    byte_order: order,
-                })
             }
+            None => Ok(JpegReader {
+                buffer: io::Cursor::new(segment),
+                byte_order: order,
+            }),
         }
-
     }
 }
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -324,19 +324,18 @@ impl EndianReader for LZWReader {
 
 pub(crate) struct JpegReader {
     buffer: io::Cursor<Vec<u8>>,
-    byte_order: ByteOrder, // for jpeg image data always ...,
+    byte_order: ByteOrder,
 }
-// Only tested with qtables in jpegtables, but it contain both qtables and huffman tables or either
 impl JpegReader {
     /// Constructs new JpegReader wrapping a SmartReader.
-    /// Because Jpeg compression in TIFF allows to save quantization and/or huffman tables in one
+    /// Because JPEG compression in TIFF allows to save quantization and/or huffman tables in one
     /// central loacation, the constructor accepts this data as `jpeg_tables` here containing either
-    /// both.
+    /// or both.
     /// These `jpeg_tables` are simply prepended to the remaining jpeg image data.
-    /// Because these jpegtables start with a `SOI` (HEX: `0xFFD8`) or __start of image__ marker
-    /// which is also at the beginning of the remaining jpeg image data and would
-    /// confuse the jpeg renderer, one of these has to be taken off. In this case the first two
-    /// bytes of the remaining jpeg data is removed because this follows `jpeg_tables`.
+    /// Because these `jpeg_tables` start with a `SOI` (HEX: `0xFFD8`) or __start of image__ marker
+    /// which is also at the beginning of the remaining JPEG image data and would
+    /// confuse the JPEG renderer, one of these has to be taken off. In this case the first two
+    /// bytes of the remaining JPEG data is removed because it follows `jpeg_tables`.
     /// Similary, `jpeg_tables` ends with a `EOI` (HEX: `0xFFD9`) or __end of image__ marker,
     /// this has to be removed as well (last two bytes of `jpeg_tables`).
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,7 @@ pub enum TiffFormatError {
     UnsignedIntegerExpected(Value),
     SignedIntegerExpected(Value),
     InflateError(InflateError),
+    Format(String),
     #[doc(hidden)]
     /// Do not match against this variant. It may get removed.
     __NonExhaustive,
@@ -80,6 +81,9 @@ impl fmt::Display for TiffFormatError {
                 write!(fmt, "Expected signed integer, {:?} found.", val)
             }
             InflateError(_) => write!(fmt, "Failed to decode inflate data."),
+            Format(ref val) => {
+                write!(fmt, "Invalid format: {:?}.", val)
+            }
             __NonExhaustive => unreachable!(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -50,6 +50,7 @@ pub enum TiffFormatError {
     SignedIntegerExpected(Value),
     InflateError(InflateError),
     Format(String),
+    RequiredTagEmpty(Tag),
     #[doc(hidden)]
     /// Do not match against this variant. It may get removed.
     __NonExhaustive,
@@ -83,6 +84,9 @@ impl fmt::Display for TiffFormatError {
             InflateError(_) => write!(fmt, "Failed to decode inflate data."),
             Format(ref val) => {
                 write!(fmt, "Invalid format: {:?}.", val)
+            }
+            RequiredTagEmpty(ref val) => {
+                write!(fmt, "Required tag {:?} was empty.", val)
             }
             __NonExhaustive => unreachable!(),
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -72,9 +72,7 @@ impl fmt::Display for TiffFormatError {
             UnknownPredictor(ref predictor) => {
                 write!(fmt, "Unknown predictor “{}” encountered", predictor)
             }
-            ByteExpected(ref val) => {
-                write!(fmt, "Expected byte, {:?} found.", val)
-            }
+            ByteExpected(ref val) => write!(fmt, "Expected byte, {:?} found.", val),
             UnsignedIntegerExpected(ref val) => {
                 write!(fmt, "Expected unsigned integer, {:?} found.", val)
             }
@@ -82,12 +80,8 @@ impl fmt::Display for TiffFormatError {
                 write!(fmt, "Expected signed integer, {:?} found.", val)
             }
             InflateError(_) => write!(fmt, "Failed to decode inflate data."),
-            Format(ref val) => {
-                write!(fmt, "Invalid format: {:?}.", val)
-            }
-            RequiredTagEmpty(ref val) => {
-                write!(fmt, "Required tag {:?} was empty.", val)
-            }
+            Format(ref val) => write!(fmt, "Invalid format: {:?}.", val),
+            RequiredTagEmpty(ref val) => write!(fmt, "Required tag {:?} was empty.", val),
             __NonExhaustive => unreachable!(),
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -45,6 +45,7 @@ pub enum TiffFormatError {
     InvalidTagValueType(Tag),
     RequiredTagNotFound(Tag),
     UnknownPredictor(u16),
+    ByteExpected(Value),
     UnsignedIntegerExpected(Value),
     SignedIntegerExpected(Value),
     InflateError(InflateError),
@@ -68,6 +69,9 @@ impl fmt::Display for TiffFormatError {
             RequiredTagNotFound(ref tag) => write!(fmt, "Required tag `{:?}` not found.", tag),
             UnknownPredictor(ref predictor) => {
                 write!(fmt, "Unknown predictor “{}” encountered", predictor)
+            }
+            ByteExpected(ref val) => {
+                write!(fmt, "Expected byte, {:?} found.", val)
             }
             UnsignedIntegerExpected(ref val) => {
                 write!(fmt, "Expected unsigned integer, {:?} found.", val)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@
 
 extern crate miniz_oxide;
 extern crate weezl;
+extern crate jpeg;
 
 mod bytecast;
 pub mod decoder;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,9 @@
 //! # Related Links
 //! * <https://www.adobe.io/open/standards/TIFF.html> - The TIFF specification
 
+extern crate jpeg;
 extern crate miniz_oxide;
 extern crate weezl;
-extern crate jpeg;
 
 mod bytecast;
 pub mod decoder;

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -130,6 +130,7 @@ pub enum Type(u16) {
     LONG = 4,
     RATIONAL = 5,
     SBYTE = 6,
+    UNDEFINED = 7,
     SSHORT = 8,
     SLONG = 9,
     SRATIONAL = 10,

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -111,6 +111,13 @@ pub enum Tag(u16) unknown("A private or extension tag") {
     Threshholding = 263, // TODO add support
     XResolution = 282,
     YResolution = 283,
+    // JPEG
+    TileWidth = 322,
+    TileLength = 323,
+    TileOffsets = 324,
+    TileByteCounts = 325,
+    SampleFormat = 339,
+    JPEGTables = 347,
     // Advanced tags
     Predictor = 317,
     TileWidth = 322,
@@ -142,6 +149,8 @@ pub enum Type(u16) {
 }
 
 tags! {
+/// See [TIFF compression tags](https://www.awaresystems.be/imaging/tiff/tifftags/compression.html)
+/// for reference.
 pub enum CompressionMethod(u16) {
     None = 1,
     Huffman = 2,
@@ -149,6 +158,8 @@ pub enum CompressionMethod(u16) {
     Fax4 = 4,
     LZW = 5,
     JPEG = 6,
+    // "Extended JPEG" or "new JPEG" style
+    ModernJPEG = 7,
     Deflate = 8,
     OldDeflate = 0x80B2,
     PackBits = 0x8005,

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -111,12 +111,12 @@ pub enum Tag(u16) unknown("A private or extension tag") {
     Threshholding = 263, // TODO add support
     XResolution = 282,
     YResolution = 283,
-    // JPEG
     TileWidth = 322,
     TileLength = 323,
     TileOffsets = 324,
     TileByteCounts = 325,
     SampleFormat = 339,
+    // JPEG
     JPEGTables = 347,
     // Advanced tags
     Predictor = 317,

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -111,11 +111,6 @@ pub enum Tag(u16) unknown("A private or extension tag") {
     Threshholding = 263, // TODO add support
     XResolution = 282,
     YResolution = 283,
-    TileWidth = 322,
-    TileLength = 323,
-    TileOffsets = 324,
-    TileByteCounts = 325,
-    SampleFormat = 339,
     // JPEG
     JPEGTables = 347,
     // Advanced tags

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -170,7 +170,7 @@ fn test_decode_data() {
     let mut decoder = Decoder::new(file).unwrap();
     assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
     assert_eq!(decoder.dimensions().unwrap(), (100, 100));
-    if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
+    if let DecodingResult::U8(img_res) = decoder.read_strip().unwrap() {
         assert_eq!(image_data, img_res);
     } else {
         panic!("Wrong data type");

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -170,7 +170,7 @@ fn test_decode_data() {
     let mut decoder = Decoder::new(file).unwrap();
     assert_eq!(decoder.colortype().unwrap(), ColorType::RGB(8));
     assert_eq!(decoder.dimensions().unwrap(), (100, 100));
-    if let DecodingResult::U8(img_res) = decoder.read_strip().unwrap() {
+    if let DecodingResult::U8(img_res) = decoder.read_image().unwrap() {
         assert_eq!(image_data, img_res);
     } else {
         panic!("Wrong data type");


### PR DESCRIPTION
Implements decoding part of #82.
# Description

Hello there,

I wrote some code to make this package compatible to the "modern JPEG" as described in the famous [technote-2](https://www.awaresystems.be/imaging/tiff/specification/TIFFTechNote2.txt).

This is my first attempt at contributing to a Rust package so please keep this in mind. As the technote states, the whole point of this revamped JPEG support was to be able to use available decoders. So this is why I used the `jpeg-decoder` package.

A few notes about this PR:
- According to `technote-2` (p.7), the`JPEGTABLES` tag can include either quantization tables, huffman tables or both. I tried with one alone and with both and it worked fine. I forgot to account for an empty `JPEGTABLES` (see open tasks below), but that should be easy enough. (Just a check)
- I successfully tested with RGB and grayscale JPEG-TIFFs and it worked fine. If others could test their images, please report problems and share your images, if possible
- In `decoder/mod.rs`: I did not follow the whole calling order of calling `read_image() -> read_strip_to_buffer() -> expand_strip()` but instead I created a new function `read_jpeg()` which is called from `read_image()`.
- I did not implement tile-wise decoding although I included the necessary tags and I want to give it a try for jpeg if it is easy enough to do.

# Open tasks
- [x] Make sure that this works with empty `JPEGTABLES`, e.g. account for the case where every segment includes its own quantization and huffman tables. (If someone can supply an example file, that would make this faster)
### Optional:
~~- [ ] Enable tile-wise reading (or remove the code that reads it and display a meaningful error message)~~ postponed to a later point in time, will make a new PR if I get this right.

---

I'll take a stab at tile-wise reading over the weekend, if this is not easily doable I'll drop it as I need to work with this soon. After this went through I want to contribute geoTIFF support (already working on that).

If people can test this, tell me what doesn't work and if someone could review my code, that would be very much appreciated. ~~Please note that some of the changes are due to auto-formatting.~~ Just rebased...