### PR TITLE
Convert to edition 2018

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ license = "MIT"
 description = "TIFF decoding and encoding library in pure Rust"
 repository = "https://github.com/image-rs/image-tiff"
 exclude = ["tests/images/*", "tests/fuzz_images/*"]
+edition = "2018"
 
 [dependencies]
 weezl = "0.1.0"

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -6,8 +6,8 @@ use std::io::{self, Read, Seek};
 use std::mem;
 
 use super::stream::{ByteOrder, EndianReader, SmartReader};
-use tags::{Tag, Type};
-use {TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
+use crate::tags::{Tag, Type};
+use crate::{TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
 use self::Value::{
     Ascii, Byte, Double, Float, List, Rational, RationalBig, SRational, SRationalBig, Signed,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -3,10 +3,12 @@ use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::io::{self, Read, Seek};
 
-use {ColorType, TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
+use crate::{ColorType, TiffError, TiffFormatError, TiffResult, TiffUnsupportedError};
 
 use self::ifd::Directory;
-use tags::{CompressionMethod, PhotometricInterpretation, Predictor, SampleFormat, Tag, Type};
+use crate::tags::{
+    CompressionMethod, PhotometricInterpretation, Predictor, SampleFormat, Tag, Type,
+};
 
 use self::stream::{
     ByteOrder, DeflateReader, EndianReader, JpegReader, LZWReader, PackBitsReader, SmartReader,

--- a/src/encoder/colortype.rs
+++ b/src/encoder/colortype.rs
@@ -1,4 +1,4 @@
-use tags::{PhotometricInterpretation, SampleFormat};
+use crate::tags::{PhotometricInterpretation, SampleFormat};
 
 /// Trait for different colortypes that can be encoded.
 pub trait ColorType {

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -3,9 +3,9 @@ use std::convert::TryFrom;
 use std::io::{Seek, Write};
 use std::{cmp, io, mem};
 
-use bytecast;
-use error::{TiffError, TiffFormatError, TiffResult};
-use tags::{self, ResolutionUnit, Tag, Type};
+use crate::bytecast;
+use crate::error::{TiffError, TiffFormatError, TiffResult};
+use crate::tags::{self, ResolutionUnit, Tag, Type};
 
 pub mod colortype;
 mod writer;

--- a/src/encoder/writer.rs
+++ b/src/encoder/writer.rs
@@ -1,4 +1,4 @@
-use error::TiffResult;
+use crate::error::TiffResult;
 use std::io::{self, Seek, SeekFrom, Write};
 
 pub fn write_tiff_header<W: Write>(writer: &mut TiffWriter<W>) -> TiffResult<()> {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,10 +3,12 @@ use std::fmt;
 use std::io;
 use std::string;
 
-use decoder::ifd::Value;
+use crate::decoder::ifd::Value;
+use crate::tags::{
+    CompressionMethod, PhotometricInterpretation, PlanarConfiguration, SampleFormat, Tag,
+};
+use crate::ColorType;
 use miniz_oxide::inflate::TINFLStatus;
-use tags::{CompressionMethod, PhotometricInterpretation, PlanarConfiguration, SampleFormat, Tag};
-use ColorType;
 
 /// Tiff error kinds.
 #[derive(Debug)]


### PR DESCRIPTION
Notably, This enables NLL even on older compilers such as 1.34.