### PR TITLE
Fix lzw decoding stopping short of full decode

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -813,8 +813,8 @@ impl<R: Read + Seek> Decoder<R> {
         if bytes / buffer.byte_len() > strip_sample_count {
             return Err(TiffError::FormatError(
                 TiffFormatError::UnexpectedCompressedData {
-                    actual: bytes,
-                    required: strip_sample_count * buffer.byte_len(),
+                    actual_bytes: bytes,
+                    required_bytes: strip_sample_count * buffer.byte_len(),
                 },
             ));
         }
@@ -1048,9 +1048,9 @@ impl<R: Read + Seek> Decoder<R> {
 
         if units_read < buffer_size {
             return Err(TiffError::FormatError(
-                TiffFormatError::InconsistentStripElements {
-                    actual: units_read,
-                    required: buffer_size,
+                TiffFormatError::InconsistentStripSamples {
+                    actual_samples: units_read,
+                    required_samples: buffer_size,
                 },
             ));
         }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -267,10 +267,11 @@ impl LZWReader {
         let mut uncompressed = Vec::with_capacity(max_uncompressed_length);
         let mut decoder = weezl::decode::Decoder::with_tiff_size_switch(weezl::BitOrder::Msb, 8);
         let mut bytes_read = 0;
-        while bytes_read < compressed_length && uncompressed.len() < max_uncompressed_length {
+
+        while uncompressed.len() < max_uncompressed_length {
             let bytes_written = uncompressed.len();
             uncompressed.reserve(1 << 12);
-            let buffer_space = uncompressed.capacity();
+            let buffer_space = uncompressed.capacity().min(max_uncompressed_length);
             uncompressed.resize(buffer_space, 0u8);
 
             let result = decoder.decode_bytes(

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,14 @@ pub enum TiffFormatError {
     TiffSignatureInvalid,
     ImageFileDirectoryNotFound,
     InconsistentSizesEncountered,
+    UnexpectedCompressedData {
+        actual: usize,
+        required: usize,
+    },
+    InconsistentStripElements {
+        actual: usize,
+        required: usize,
+    },
     InvalidTag,
     InvalidTagValueType(Tag),
     RequiredTagNotFound(Tag),
@@ -66,6 +74,20 @@ impl fmt::Display for TiffFormatError {
             TiffSignatureInvalid => write!(fmt, "TIFF signature invalid."),
             ImageFileDirectoryNotFound => write!(fmt, "Image file directory not found."),
             InconsistentSizesEncountered => write!(fmt, "Inconsistent sizes encountered."),
+            UnexpectedCompressedData { actual, required } => {
+                write!(
+                    fmt,
+                    "Decompression returned different amount of bytes than expected: got {}, expected {}.",
+                    actual, required
+                )
+            }
+            InconsistentStripElements { actual, required } => {
+                write!(
+                    fmt,
+                    "Inconsistent elements in strip: got {}, expected {}.",
+                    actual, required
+                )
+            }
             InvalidTag => write!(fmt, "Image contains invalid tag."),
             InvalidTagValueType(ref tag) => {
                 write!(fmt, "Tag `{:?}` did not have the expected value type.", tag)

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,12 +44,12 @@ pub enum TiffFormatError {
     ImageFileDirectoryNotFound,
     InconsistentSizesEncountered,
     UnexpectedCompressedData {
-        actual: usize,
-        required: usize,
+        actual_bytes: usize,
+        required_bytes: usize,
     },
-    InconsistentStripElements {
-        actual: usize,
-        required: usize,
+    InconsistentStripSamples {
+        actual_samples: usize,
+        required_samples: usize,
     },
     InvalidTag,
     InvalidTagValueType(Tag),
@@ -74,18 +74,24 @@ impl fmt::Display for TiffFormatError {
             TiffSignatureInvalid => write!(fmt, "TIFF signature invalid."),
             ImageFileDirectoryNotFound => write!(fmt, "Image file directory not found."),
             InconsistentSizesEncountered => write!(fmt, "Inconsistent sizes encountered."),
-            UnexpectedCompressedData { actual, required } => {
+            UnexpectedCompressedData {
+                actual_bytes,
+                required_bytes,
+            } => {
                 write!(
                     fmt,
                     "Decompression returned different amount of bytes than expected: got {}, expected {}.",
-                    actual, required
+                    actual_bytes, required_bytes
                 )
             }
-            InconsistentStripElements { actual, required } => {
+            InconsistentStripSamples {
+                actual_samples,
+                required_samples,
+            } => {
                 write!(
                     fmt,
                     "Inconsistent elements in strip: got {}, expected {}.",
-                    actual, required
+                    actual_samples, required_samples
                 )
             }
             InvalidTag => write!(fmt, "Image contains invalid tag."),


### PR DESCRIPTION
When the required amount of data was just a tiny bit larger than full a
page size (one buffer increment), the decoder would stop since all
compressed data had been read. However, the lzw decoder contains a small
internal bit buffer for code decoding. That is, some remaining bytes had
been retained and were still left to be decoded.

Analysis was complicated by a (probably) incorrect sign in a sanity
check: We had a check that the decompressed bytes were at most as large
as required. Instead, we need at least as much data as required while an
internal invariant should stop at the request size, but it's not a
critical format error. This has been replaced with more concise errors.

Closes: #106 