### PR TITLE
Open tif files containing i32 arrays

### DIFF
--- a/src/bytecast.rs
+++ b/src/bytecast.rs
@@ -27,7 +27,7 @@ integral_slice_as_bytes!(i8, i8_as_ne_bytes, i8_as_ne_mut_bytes);
 integral_slice_as_bytes!(u16, u16_as_ne_bytes, u16_as_ne_mut_bytes);
 integral_slice_as_bytes!(i16, i16_as_ne_bytes, i16_as_ne_mut_bytes);
 integral_slice_as_bytes!(u32, u32_as_ne_bytes, u32_as_ne_mut_bytes);
-integral_slice_as_bytes!(i32, i32_as_ne_bytes);
+integral_slice_as_bytes!(i32, i32_as_ne_bytes, i32_as_ne_mut_bytes);
 integral_slice_as_bytes!(u64, u64_as_ne_bytes, u64_as_ne_mut_bytes);
 integral_slice_as_bytes!(f32, f32_as_ne_bytes, f32_as_ne_mut_bytes);
 integral_slice_as_bytes!(f64, f64_as_ne_bytes, f64_as_ne_mut_bytes);

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -135,6 +135,24 @@ pub trait EndianReader: Read {
         Ok(())
     }
 
+    #[inline(always)]
+    fn read_i32_into(&mut self, buffer: &mut [i32]) -> Result<(), io::Error> {
+        self.read_exact(bytecast::i32_as_ne_mut_bytes(buffer))?;
+        match self.byte_order() {
+            ByteOrder::LittleEndian => {
+                for n in buffer {
+                    *n = i32::from_le(*n);
+                }
+            }
+            ByteOrder::BigEndian => {
+                for n in buffer {
+                    *n = i32::from_be(*n);
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Reads an i32
     #[inline(always)]
     fn read_i32(&mut self) -> Result<i32, io::Error> {


### PR DESCRIPTION
I use image-tiff to open frames which are produced by various x-ray detectors. It worked fine until I met a tiff file from Dectris Pilatus detector. This detector uses negative values to mask dead pixels, and, consequently it stores i32 arrays in tiff file. A sample file can be downloaded from here:
https://cloud.esrf.fr/s/i4YLE9Pyb6dHGES
I wrote a trivial patch which allows to open those tiffs. Let me know how I can make it better.