### PR TITLE
Improve deflate support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,7 @@ edition = "2018"
 [dependencies]
 weezl = "0.1.0"
 jpeg = { package = "jpeg-decoder", version = "0.1.17", default-features = false }
-
-[dependencies.miniz_oxide]
-version = "0.4.1"
-features = ["no_extern_crate_alloc"]
+flate2 = "1.0.20"
 
 [dev-dependencies]
 criterion = "0.3.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,7 +9,6 @@ use crate::tags::{
     CompressionMethod, PhotometricInterpretation, PlanarConfiguration, SampleFormat, Tag,
 };
 use crate::ColorType;
-use miniz_oxide::inflate::TINFLStatus;
 
 /// Tiff error kinds.
 #[derive(Debug)]
@@ -62,6 +61,7 @@ pub enum TiffFormatError {
     ByteExpected(Value),
     UnsignedIntegerExpected(Value),
     SignedIntegerExpected(Value),
+    #[allow(deprecated)]
     InflateError(InflateError),
     Format(String),
     RequiredTagEmpty(Tag),
@@ -123,21 +123,9 @@ impl fmt::Display for TiffFormatError {
 
 /// Decompression failed due to faulty compressed data.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct InflateError {
-    status: TINFLStatus,
-}
-
-impl InflateError {
-    pub(crate) fn new(status: TINFLStatus) -> Self {
-        Self { status }
-    }
-}
-
-impl TiffError {
-    pub(crate) fn from_inflate_status(status: TINFLStatus) -> Self {
-        TiffError::FormatError(TiffFormatError::InflateError(InflateError::new(status)))
-    }
-}
+#[allow(deprecated)]
+#[deprecated = "This type is not used anymore: deflate errors are now propagated as regular `io::Error`s"]
+pub struct InflateError(());
 
 /// The Decoder does not support features required by the image.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! * <https://www.adobe.io/open/standards/TIFF.html> - The TIFF specification
 
 extern crate jpeg;
-extern crate miniz_oxide;
 extern crate weezl;
 
 mod bytecast;
@@ -16,9 +15,10 @@ pub mod encoder;
 mod error;
 pub mod tags;
 
-pub use self::error::{
-    InflateError, TiffError, TiffFormatError, TiffResult, TiffUnsupportedError, UsageError,
-};
+pub use self::error::{TiffError, TiffFormatError, TiffResult, TiffUnsupportedError, UsageError};
+
+#[allow(deprecated)]
+pub use self::error::InflateError;
 
 /// An enumeration over supported color types and their bit depths
 #[derive(Copy, PartialEq, Eq, Debug, Clone, Hash)]


### PR DESCRIPTION
- Switch to streaming decompression via `flate2`. Aside from performance improvements and lower RAM consumption, this fixes a bug where `max_uncompressed_length` was precalculated for a single tile but then used as a hard limit on the whole data, failing to decompress any tiled images.
 - Deprecate `InflateError` - this was used for wrapping `miniz_oxide` raw status, but `flate2` already reports them as `io::Error` instead. This makes errors from both Lzw and Deflate modes more consistent - they're all now just `io::Error`.
 - Add support for new `Deflate` tag in addition to `OldDeflate` - format-wise it's same Zlib, and on practice decodes successfully with the same underlying code.
 - Slightly simplify partial reads from the `Reader` by using the `std::io::copy` helper instead of doing it manually.

Fixes #131.