### PR TITLE
Add fuzzer with 1MB size limits decoding image

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,3 @@
+target
+corpus
+artifacts

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "tiff-fuzz"
+version = "0.0.0"
+authors = ["Automatically generated"]
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+
+[dependencies.tiff]
+path = ".."
+
+# Prevent this from interfering with workspaces
+[workspace]
+members = ["."]
+
+[[bin]]
+name = "decode_image"
+path = "fuzz_targets/decode_image.rs"
+test = false
+doc = false

--- a/fuzz/fuzz_targets/decode_image.rs
+++ b/fuzz/fuzz_targets/decode_image.rs
@@ -14,6 +14,14 @@ fuzz_target!(|data: &[u8]| {
     limits.intermediate_buffer_size = 1_000_000;
 
     decoder = decoder.with_limits(limits);
+    
+    loop {
+        if let Err(_) = decoder.read_image() {
+            break;
+        }
 
-    let _ = decoder.read_image();
+        if !decoder.more_images() {
+            break;
+        }
+    }
 });

--- a/fuzz/fuzz_targets/decode_image.rs
+++ b/fuzz/fuzz_targets/decode_image.rs
@@ -1,0 +1,19 @@
+#![no_main]
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let mut decoder = if let Ok(d) = tiff::decoder::Decoder::new(std::io::Cursor::new(data)) {
+        d
+    } else {
+        return;
+    };
+
+    let mut limits = tiff::decoder::Limits::default();
+    limits.decoding_buffer_size = 1_000_000;
+    limits.ifd_value_size = 1_000_000;
+    limits.intermediate_buffer_size = 1_000_000;
+
+    decoder = decoder.with_limits(limits);
+
+    let _ = decoder.read_image();
+});


### PR DESCRIPTION
re: https://github.com/image-rs/image-tiff/pull/139#pullrequestreview-671738717

By adding the regression tests in a separate directory, do you mean `tests/fuzz_images/<category>`?

I've not really been saving the files for the failures, since I figure it's easy enough to find more failing test cases as needed. I can start saving them in that director. I've just been adding the first one I find of a particular failure to the test `.rs` file as an array.

And/or should I save the corpus somewhere?