### PR TITLE
fixed deflate and packbits

### DIFF
--- a/src/encoder/compression/deflate.rs
+++ b/src/encoder/compression/deflate.rs
@@ -53,7 +53,7 @@ impl Compression for Deflate {
 impl CompressionAlgorithm for Deflate {
     fn write_to<W: Write>(&mut self, writer: &mut W, bytes: &[u8]) -> Result<u64, io::Error> {
         let mut encoder = ZlibEncoder::new(writer, self.level);
-        encoder.write(&bytes)?;
+        encoder.write_all(&bytes)?;
         encoder.try_finish()?;
         Ok(encoder.total_out())
     }

--- a/src/encoder/compression/packbits.rs
+++ b/src/encoder/compression/packbits.rs
@@ -122,6 +122,7 @@ impl CompressionAlgorithm for Packbits {
             bufwriter.write(&bytes[pending_index..pending_index + bytes_pending as usize])?;
         }
 
+        bufwriter.flush()?;
         Ok(bytes_written)
     }
 }

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -354,7 +354,12 @@ impl<'a, W: 'a + Write + Seek, T: ColorType, K: TiffKind, D: Compression>
 
         // Limit the strip size to prevent potential memory and security issues.
         // Also keep the multiple strip handling 'oiled'
-        let rows_per_strip = (1_000_000 + row_bytes - 1) / row_bytes;
+        let rows_per_strip = {
+            match D::COMPRESSION_METHOD {
+                crate::tags::CompressionMethod::PackBits => 1, // Each row must be packed separately. Do not compress across row boundaries
+                _ => (1_000_000 + row_bytes - 1) / row_bytes,
+            }
+        };
 
         let strip_count = (u64::from(height) + rows_per_strip - 1) / rows_per_strip;
 

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -12,7 +12,7 @@ use std::{
 
 use crate::{
     error::TiffResult,
-    tags::{ResolutionUnit, Tag},
+    tags::{CompressionMethod, ResolutionUnit, Tag},
 };
 
 pub mod colortype;
@@ -356,7 +356,7 @@ impl<'a, W: 'a + Write + Seek, T: ColorType, K: TiffKind, D: Compression>
         // Also keep the multiple strip handling 'oiled'
         let rows_per_strip = {
             match D::COMPRESSION_METHOD {
-                crate::tags::CompressionMethod::PackBits => 1, // Each row must be packed separately. Do not compress across row boundaries
+                CompressionMethod::PackBits => 1, // Each row must be packed separately. Do not compress across row boundaries
                 _ => (1_000_000 + row_bytes - 1) / row_bytes,
             }
         };


### PR DESCRIPTION
I saw a problem with the compression when I saved some images on Windows. 
The preview showed a corrupted image when compressed with Deflate or Packbits. 
These small changes fix this problem.