### PR TITLE
Added ability to decompress tiled jpeg files

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1533,9 +1533,9 @@ impl<R: Read + Seek> Decoder<R> {
 
     /// Decodes the entire image and return it as a Vector
     pub fn read_image(&mut self) -> TiffResult<DecodingResult> {
-        let result = match (self.image().chunk_type, self.image().compression_method) {
-            (ChunkType::Strip, _) => self.read_stripped_image()?,
-            (ChunkType::Tile, _) => self.read_tiled_image()?,
+        let result = match self.image().chunk_type {
+            ChunkType::Strip => self.read_stripped_image()?,
+            ChunkType::Tile => self.read_tiled_image()?,
         };
 
         Ok(result)

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1153,14 +1153,13 @@ impl<R: Read + Seek> Decoder<R> {
                     ));
                 }
 
-                // TODO: avoid this clone
                 let jpeg_tables = decoder.image().jpeg_tables.clone();
                 let photometric_interpretation = decoder.image().photometric_interpretation;
 
                 let jpeg_reader = JpegReader::new(
                     &mut decoder.reader,
                     compressed_length,
-                    &jpeg_tables,
+                    jpeg_tables,
                     &photometric_interpretation,
                 )?;
                 let mut decoder = jpeg::Decoder::new(jpeg_reader);
@@ -1248,14 +1247,14 @@ impl<R: Read + Seek> Decoder<R> {
                     TiffFormatError::InvalidTagValueType(Tag::JPEGTables),
                 ));
             }
-            // TODO: avoid this clone
+
             let jpeg_tables = self.image().jpeg_tables.clone();
             let photometric_interpretation = self.image().photometric_interpretation;
 
             let jpeg_reader = JpegReader::new(
                 &mut self.reader,
                 length,
-                &jpeg_tables,
+                jpeg_tables,
                 &photometric_interpretation,
             )?;
             let mut decoder = jpeg::Decoder::new(jpeg_reader);

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1032,17 +1032,11 @@ impl<R: Read + Seek> Decoder<R> {
         self.goto_offset_u64(offset)?;
         let byte_order = self.reader.byte_order;
 
-        let photometric_interpretation = self.image().photometric_interpretation;
         let compression_method = self.image().compression_method;
         let jpeg_tables = self.image().jpeg_tables.clone();
 
-        let reader = Self::create_reader(
-            &mut self.reader,
-            photometric_interpretation,
-            compression_method,
-            length,
-            jpeg_tables,
-        )?;
+        let reader =
+            Self::create_reader(&mut self.reader, compression_method, length, jpeg_tables)?;
 
         // Read into output buffer.
         {
@@ -1105,7 +1099,6 @@ impl<R: Read + Seek> Decoder<R> {
 
         let mut reader = Self::create_reader(
             &mut self.reader,
-            photometric_interpretation,
             compression_method,
             compressed_length,
             jpeg_tables,
@@ -1149,7 +1142,6 @@ impl<R: Read + Seek> Decoder<R> {
 
     fn create_reader<'r>(
         reader: &'r mut SmartReader<R>,
-        photometric_interpretation: PhotometricInterpretation,
         compression_method: CompressionMethod,
         compressed_length: u64,
         jpeg_tables: Option<Arc<Vec<u8>>>,
@@ -1170,12 +1162,7 @@ impl<R: Read + Seek> Decoder<R> {
                     ));
                 }
 
-                let jpeg_reader = JpegReader::new(
-                    reader,
-                    compressed_length,
-                    jpeg_tables,
-                    &photometric_interpretation,
-                )?;
+                let jpeg_reader = JpegReader::new(reader, compressed_length, jpeg_tables)?;
                 let mut decoder = jpeg::Decoder::new(jpeg_reader);
                 let data = decoder.decode().unwrap();
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -208,7 +208,7 @@ impl JpegReader {
     pub fn new<R>(
         reader: &mut SmartReader<R>,
         length: u64,
-        jpeg_tables: &Option<Vec<u8>>,
+        jpeg_tables: Option<Vec<u8>>,
         photometric_interpretation: &PhotometricInterpretation,
     ) -> io::Result<JpegReader>
     where
@@ -220,11 +220,11 @@ impl JpegReader {
         reader.read_exact(&mut segment[..])?;
 
         match jpeg_tables {
-            Some(tables) => {
+            Some(mut jpeg_data) => {
                 assert!(
-                    tables.len() >= 2,
+                    jpeg_data.len() >= 2,
                     "jpeg_tables, if given, must be at least 2 bytes long. Got {:?}",
-                    tables
+                    jpeg_data
                 );
 
                 assert!(
@@ -233,7 +233,6 @@ impl JpegReader {
                     length
                 );
 
-                let mut jpeg_data = tables.clone();
                 if photometric_interpretation == &PhotometricInterpretation::RGB {
                     add_app14segment(&mut jpeg_data, JpegTagApp14Transform::App14TransformUnknown)
                 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -240,16 +240,8 @@ impl JpegReader {
                     length
                 );
 
-                // if photometric_interpretation == &PhotometricInterpretation::RGB {
-                //     add_app14segment(&mut jpeg_data, JpegTagApp14Transform::App14TransformUnknown)
-                // }
-
-                // let truncated_length = jpeg_data.len() - 2;
-                // jpeg_data.truncate(truncated_length);
-                // jpeg_data.extend_from_slice(&segment[2..]);
-
                 let mut buffer = io::Cursor::new(segment);
-                // Skip the first two bytes
+                // Skip the first two bytes (marker bytes)
                 buffer.seek(SeekFrom::Start(2))?;
 
                 Ok(JpegReader {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,7 +1,8 @@
 //! All IO functionality needed for TIFF decoding
 
 use std::convert::TryFrom;
-use std::io::{self, BufRead, BufReader, Read, Seek, Take};
+use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom, Take};
+use std::sync::Arc;
 
 use crate::tags::PhotometricInterpretation;
 
@@ -189,7 +190,13 @@ impl<R: Read> Read for LZWReader<R> {
 ///
 
 pub(crate) struct JpegReader {
+    jpeg_tables: Option<Arc<Vec<u8>>>,
+
+    photometric_interpretation: Option<PhotometricInterpretation>,
+
     buffer: io::Cursor<Vec<u8>>,
+
+    offset: usize,
 }
 
 impl JpegReader {
@@ -208,7 +215,7 @@ impl JpegReader {
     pub fn new<R>(
         reader: &mut SmartReader<R>,
         length: u64,
-        jpeg_tables: Option<Vec<u8>>,
+        jpeg_tables: Option<Arc<Vec<u8>>>,
         photometric_interpretation: &PhotometricInterpretation,
     ) -> io::Result<JpegReader>
     where
@@ -220,11 +227,11 @@ impl JpegReader {
         reader.read_exact(&mut segment[..])?;
 
         match jpeg_tables {
-            Some(mut jpeg_data) => {
+            Some(jpeg_tables) => {
                 assert!(
-                    jpeg_data.len() >= 2,
+                    jpeg_tables.len() >= 2,
                     "jpeg_tables, if given, must be at least 2 bytes long. Got {:?}",
-                    jpeg_data
+                    jpeg_tables
                 );
 
                 assert!(
@@ -233,33 +240,43 @@ impl JpegReader {
                     length
                 );
 
-                if photometric_interpretation == &PhotometricInterpretation::RGB {
-                    add_app14segment(&mut jpeg_data, JpegTagApp14Transform::App14TransformUnknown)
-                }
+                // if photometric_interpretation == &PhotometricInterpretation::RGB {
+                //     add_app14segment(&mut jpeg_data, JpegTagApp14Transform::App14TransformUnknown)
+                // }
 
-                let truncated_length = jpeg_data.len() - 2;
-                jpeg_data.truncate(truncated_length);
-                jpeg_data.extend_from_slice(&segment[2..]);
+                // let truncated_length = jpeg_data.len() - 2;
+                // jpeg_data.truncate(truncated_length);
+                // jpeg_data.extend_from_slice(&segment[2..]);
+
+                let mut buffer = io::Cursor::new(segment);
+                // Skip the first two bytes
+                buffer.seek(SeekFrom::Start(2))?;
 
                 Ok(JpegReader {
-                    buffer: io::Cursor::new(jpeg_data),
+                    buffer,
+                    jpeg_tables: Some(jpeg_tables),
+                    photometric_interpretation: Some(*photometric_interpretation),
+                    offset: 0,
                 })
             }
             None => Ok(JpegReader {
                 buffer: io::Cursor::new(segment),
+                jpeg_tables: None,
+                photometric_interpretation: None,
+                offset: 0,
             }),
         }
     }
 }
 
 #[repr(u8)]
-enum JpegTagApp14Transform {
+pub(crate) enum JpegTagApp14Transform {
     // App14TransformYCCK = 2,
     // App14TransformYCbCr = 1,
     App14TransformUnknown = 0,
 }
 
-fn add_app14segment(jpeg_tables: &mut Vec<u8>, transform: JpegTagApp14Transform) {
+pub(crate) fn add_app14segment(jpeg_tables: &mut Vec<u8>, transform: JpegTagApp14Transform) {
     // Add JPEG Tag APP14 Adobe segment to jpeg_tables.
     // This segment stores image encoding information for DCT filters.
     // When `transform` value is 0 which is defined as Unknown, jpeg-decoder interpret the
@@ -307,7 +324,31 @@ fn add_app14segment(jpeg_tables: &mut Vec<u8>, transform: JpegTagApp14Transform)
 impl Read for JpegReader {
     // #[inline]
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.buffer.read(buf)
+        let mut start = 0;
+
+        if let Some(jpeg_tables) = &self.jpeg_tables {
+            if jpeg_tables.len() - 2 > self.offset {
+                // Read (rest of) jpeg_tables to buf (without the last two bytes)
+                let size_remaining = jpeg_tables.len() - self.offset - 2;
+                let to_copy = size_remaining.min(buf.len());
+
+                buf[start..start + to_copy]
+                    .copy_from_slice(&jpeg_tables[self.offset..self.offset + to_copy]);
+
+                self.offset += to_copy;
+
+                if to_copy == buf.len() {
+                    return Ok(to_copy);
+                }
+
+                start += to_copy;
+            }
+        }
+
+        let read = self.buffer.read(&mut buf[start..])?;
+        self.offset += read;
+
+        Ok(read + start)
     }
 }
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -192,8 +192,6 @@ impl<R: Read> Read for LZWReader<R> {
 pub(crate) struct JpegReader {
     jpeg_tables: Option<Arc<Vec<u8>>>,
 
-    photometric_interpretation: Option<PhotometricInterpretation>,
-
     buffer: io::Cursor<Vec<u8>>,
 
     offset: usize,
@@ -216,7 +214,6 @@ impl JpegReader {
         reader: &mut SmartReader<R>,
         length: u64,
         jpeg_tables: Option<Arc<Vec<u8>>>,
-        photometric_interpretation: &PhotometricInterpretation,
     ) -> io::Result<JpegReader>
     where
         R: Read + Seek,
@@ -247,14 +244,12 @@ impl JpegReader {
                 Ok(JpegReader {
                     buffer,
                     jpeg_tables: Some(jpeg_tables),
-                    photometric_interpretation: Some(*photometric_interpretation),
                     offset: 0,
                 })
             }
             None => Ok(JpegReader {
                 buffer: io::Cursor::new(segment),
                 jpeg_tables: None,
-                photometric_interpretation: None,
                 offset: 0,
             }),
         }

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -391,6 +391,10 @@ fn oom() {
 
     match err {
         tiff::TiffError::LimitsExceeded => {}
+        tiff::TiffError::UnsupportedError(tiff::TiffUnsupportedError::InterpretationWithBits(
+            _,
+            _,
+        )) => {}
         unexpected => panic!("Unexpected error {}", unexpected),
     }
 }
@@ -452,6 +456,7 @@ fn invalid_jpeg_tag_2() {
 
     match err {
         TiffError::FormatError(TiffFormatError::InvalidTagValueType(tags::Tag::JPEGTables)) => {}
+        TiffError::LimitsExceeded => {}
         unexpected => panic!("Unexpected error {}", unexpected),
     }
 }

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -390,10 +390,8 @@ fn oom() {
     let err = decoder.read_image().unwrap_err();
 
     match err {
-        tiff::TiffError::LimitsExceeded => {}
         tiff::TiffError::UnsupportedError(tiff::TiffUnsupportedError::InterpretationWithBits(
-            _,
-            _,
+            ..,
         )) => {}
         unexpected => panic!("Unexpected error {}", unexpected),
     }


### PR DESCRIPTION
Currently compression type 7 (`ModernJPEG`) is not supported when expanding either a strip or a tile. This means that it is not possible to load a single tile of an image (e.g. via `read_tile`) with this compression (only `read_image` can be used). 

To make sure that the correct data is displayed for the test data I was using, I had to incorporate the changes from https://github.com/image-rs/image-tiff/pull/148 too.

This also removes the special case for handling `ModernJPEG` in `read_image`.