### PR TITLE
Removed `unwrap` and set colour transform with Jpeg compressed tiffs

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -358,7 +358,6 @@ impl Image {
                     PhotometricInterpretation::BlackIsZero => {
                         decoder.set_color_transform(jpeg::ColorTransform::None)
                     }
-                    PhotometricInterpretation::RGBPalette => todo!(),
                     PhotometricInterpretation::TransparencyMask => {
                         decoder.set_color_transform(jpeg::ColorTransform::None)
                     }
@@ -368,8 +367,13 @@ impl Image {
                     PhotometricInterpretation::YCbCr => {
                         decoder.set_color_transform(jpeg::ColorTransform::YCbCr)
                     }
-                    PhotometricInterpretation::CIELab => todo!(),
-                    _ => todo!(),
+                    photometric_interpretation => {
+                        return Err(TiffError::UnsupportedError(
+                            TiffUnsupportedError::UnsupportedInterpretation(
+                                photometric_interpretation,
+                            ),
+                        ));
+                    }
                 }
 
                 let data = decoder.decode()?;

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -1,8 +1,5 @@
 use super::ifd::{Directory, Value};
-use super::stream::{
-    add_app14segment, ByteOrder, DeflateReader, JpegReader, JpegTagApp14Transform, LZWReader,
-    PackBitsReader,
-};
+use super::stream::{ByteOrder, DeflateReader, JpegReader, LZWReader, PackBitsReader};
 use super::tag_reader::TagReader;
 use super::{fp_predict_f32, fp_predict_f64, DecodingBuffer, Limits};
 use super::{stream::SmartReader, ChunkType};
@@ -121,7 +118,7 @@ impl Image {
         let jpeg_tables = if compression_method == CompressionMethod::ModernJPEG
             && ifd.contains_key(&Tag::JPEGTables)
         {
-            let mut vec = tag_reader
+            let vec = tag_reader
                 .find_tag(Tag::JPEGTables)?
                 .unwrap()
                 .into_u8_vec()?;
@@ -129,11 +126,6 @@ impl Image {
                 return Err(TiffError::FormatError(
                     TiffFormatError::InvalidTagValueType(Tag::JPEGTables),
                 ));
-            }
-
-            // TODO: Can we avoid this somehow?
-            if photometric_interpretation == PhotometricInterpretation::RGB {
-                add_app14segment(&mut vec, JpegTagApp14Transform::App14TransformUnknown)
             }
 
             Some(Arc::new(vec))
@@ -332,6 +324,7 @@ impl Image {
 
     fn create_reader<'r, R: 'r + Read>(
         reader: R,
+        photometric_interpretation: PhotometricInterpretation,
         compression_method: CompressionMethod,
         compressed_length: u64,
         jpeg_tables: Option<Arc<Vec<u8>>>,
@@ -354,14 +347,32 @@ impl Image {
 
                 let jpeg_reader = JpegReader::new(reader, compressed_length, jpeg_tables)?;
                 let mut decoder = jpeg::Decoder::new(jpeg_reader);
-                let data = match decoder.decode() {
-                    Ok(data) => data,
-                    Err(e) => {
-                        return Err(TiffError::FormatError(TiffFormatError::Format(
-                            e.to_string(),
-                        )))
+
+                match photometric_interpretation {
+                    PhotometricInterpretation::RGB => {
+                        decoder.set_color_transform(jpeg::ColorTransform::RGB)
                     }
-                };
+                    PhotometricInterpretation::WhiteIsZero => {
+                        decoder.set_color_transform(jpeg::ColorTransform::None)
+                    }
+                    PhotometricInterpretation::BlackIsZero => {
+                        decoder.set_color_transform(jpeg::ColorTransform::None)
+                    }
+                    PhotometricInterpretation::RGBPalette => todo!(),
+                    PhotometricInterpretation::TransparencyMask => {
+                        decoder.set_color_transform(jpeg::ColorTransform::None)
+                    }
+                    PhotometricInterpretation::CMYK => {
+                        decoder.set_color_transform(jpeg::ColorTransform::CMYK)
+                    }
+                    PhotometricInterpretation::YCbCr => {
+                        decoder.set_color_transform(jpeg::ColorTransform::YCbCr)
+                    }
+                    PhotometricInterpretation::CIELab => todo!(),
+                    _ => todo!(),
+                }
+
+                let data = decoder.decode()?;
 
                 Box::new(Cursor::new(data))
             }
@@ -509,8 +520,13 @@ impl Image {
         let padding_right = chunk_dims.0 - data_dims.0;
 
         let jpeg_tables = self.jpeg_tables.clone();
-        let mut reader =
-            Self::create_reader(reader, compression_method, *compressed_bytes, jpeg_tables)?;
+        let mut reader = Self::create_reader(
+            reader,
+            photometric_interpretation,
+            compression_method,
+            *compressed_bytes,
+            jpeg_tables,
+        )?;
 
         if output_width == data_dims.0 as usize && padding_right == 0 {
             let total_samples = data_dims.0 as usize * data_dims.1 as usize * samples;

--- a/src/error.rs
+++ b/src/error.rs
@@ -148,10 +148,8 @@ pub enum TiffUnsupportedError {
     UnsupportedBitsPerChannel(u8),
     UnsupportedPlanarConfig(Option<PlanarConfiguration>),
     UnsupportedDataType,
+    UnsupportedInterpretation(PhotometricInterpretation),
     UnsupportedJpegFeature(UnsupportedFeature),
-    #[doc(hidden)]
-    /// Do not match against this variant. It may get removed.
-    __NonExhaustive,
 }
 
 impl fmt::Display for TiffUnsupportedError {
@@ -197,10 +195,16 @@ impl fmt::Display for TiffUnsupportedError {
                 write!(fmt, "Unsupported planar configuration “{:?}”.", config)
             }
             UnsupportedDataType => write!(fmt, "Unsupported data type."),
+            UnsupportedInterpretation(interpretation) => {
+                write!(
+                    fmt,
+                    "Unsupported photometric interpretation \"{:?}\".",
+                    interpretation
+                )
+            }
             UnsupportedJpegFeature(ref unsupported_feature) => {
                 write!(fmt, "Unsupported JPEG feature {:?}", unsupported_feature)
             }
-            __NonExhaustive => unreachable!(),
         }
     }
 }


### PR DESCRIPTION
This pull request includes better handling of jpeg compressed tiff files. The `unwrap` is removed, and instead an error (`TiffUnsupportedError::UnsupportedJpegFeature`) created and propogated back.

This also removes the hacky `add_app14segment` for setting which colour transform the `jpeg-decode` crate should expect and decode. Now the new `set_color_transform` is used based on the `PhotometricInterpretation` set in the tiff file.


Requires merging of https://github.com/image-rs/jpeg-decoder/pull/254 and https://github.com/image-rs/jpeg-decoder/pull/255 in the `jpeg-decoder` crate.

This fixes https://github.com/image-rs/image-tiff/issues/168