### PR TITLE
Add check to verify start index within size of buffer

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1224,6 +1224,13 @@ impl<R: Read + Seek> Decoder<R> {
             let x = chunk % chunks_across;
             let y = chunk / chunks_across;
             let buffer_offset = y * strip_samples + x * chunk_dimensions.0 as usize * samples;
+            if buffer_offset * result.as_buffer(0).byte_len()
+                > result.as_buffer(0).as_bytes_mut().len()
+            {
+                return Err(TiffError::FormatError(
+                    TiffFormatError::InconsistentSizesEncountered,
+                ));
+            }
             let byte_order = self.reader.byte_order;
             self.image.expand_chunk(
                 &mut self.reader,


### PR DESCRIPTION
The chunk dimensions are untrusted user input and so the buffer_offset
in `read_input()` must be verified as being within the buffer or else
`result.as_buffer()` may panic.

Fixes #171