### PR TITLE
Handle possible JPEG decoder errors

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -345,7 +345,14 @@ impl Image {
 
                 let jpeg_reader = JpegReader::new(reader, compressed_length, jpeg_tables)?;
                 let mut decoder = jpeg::Decoder::new(jpeg_reader);
-                let data = decoder.decode().unwrap();
+                let data = match decoder.decode() {
+                    Ok(data) => data,
+                    Err(e) => {
+                        return Err(TiffError::FormatError(TiffFormatError::Format(
+                            e.to_string(),
+                        )))
+                    }
+                };
 
                 Box::new(Cursor::new(data))
             }


### PR DESCRIPTION
The JPEG decoder may fail and panic the TIFF decoder. This commit
converts the JPEG `Format(String)` error to a TIFF `Format(String)`
error.

Fixes #168