### PR TITLE
Bump jpeg-decoder version pin to 0.3.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.48", stable, beta, nightly]
+        rust: ["1.61", stable, beta, nightly]
         command: [build, test]
     steps:
     - uses: actions/checkout@v2
@@ -20,7 +20,7 @@ jobs:
     - name: test
       run: >
         cargo test --tests --benches --no-default-features --features "$FEATURES"
-      if: ${{ matrix.rust != '1.48' }}
+      if: ${{ matrix.rust != '1.61' }}
       env:
         FEATURES: ${{ matrix.features }}
   rustfmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 weezl = "0.1.0"
-jpeg = { package = "jpeg-decoder", version = "0.2.4", default-features = false }
+jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false }
 flate2 = "1.0.20"
 
 [dev-dependencies]


### PR DESCRIPTION
The jpeg-decoder project has a new version with a number of improvements plus a fix for a possible panic.  I noticed just today that semantic versioning rules have us stuck on the older jpeg-decoder version.

Semantic versioning considers 0.2.4 to be incompatible with 0.3.X because of the leading zero, so this change bumps the pin to 0.3.0: https://doc.rust-lang.org/cargo/reference/resolver.html#semver-compatibility

> Versions are considered compatible if their left-most non-zero major/minor/patch component is the same.

Personally I would prefer to remove the version pins entirely, so we don't accidentally ship new versions of the tiff project pinned to older dependencies (again).  
But at a minimum I'd be happy to get this change in, and then if you can please publish another patch release for `image-tiff` I would be grateful. 🙏 