### PR TITLE
Non exhaustive enumerations

### DIFF
--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -17,6 +17,7 @@ use self::Value::{
 
 #[allow(unused_qualifications)]
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum Value {
     Byte(u8),
     Short(u16),
@@ -34,8 +35,6 @@ pub enum Value {
     Ascii(String),
     Ifd(u32),
     IfdBig(u64),
-    #[doc(hidden)] // Do not match against this.
-    __NonExhaustive,
 }
 
 impl Value {
@@ -361,7 +360,6 @@ impl Entry {
             | Type::RATIONAL
             | Type::SRATIONAL
             | Type::IFD8 => 8,
-            Type::__NonExhaustive => unreachable!(),
         };
 
         let value_bytes = match self.count.checked_mul(tag_size) {
@@ -398,7 +396,6 @@ impl Entry {
                     | Type::SLONG
                     | Type::FLOAT
                     | Type::IFD => unreachable!(),
-                    Type::__NonExhaustive => unreachable!(),
                 });
             }
 
@@ -444,7 +441,6 @@ impl Entry {
                     reader.goto_offset(self.r(bo).read_u32()?.into())?;
                     IfdBig(reader.read_u64()?)
                 }
-                Type::__NonExhaustive => unreachable!(),
             });
         }
 
@@ -528,7 +524,6 @@ impl Entry {
                 | Type::IFD8 => {
                     unreachable!()
                 }
-                Type::__NonExhaustive => unreachable!(),
             }
         }
 
@@ -611,7 +606,6 @@ impl Entry {
                 }
                 Ok(Ascii(String::from_utf8(out)?))
             }
-            Type::__NonExhaustive => unreachable!(),
         }
     }
 

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -464,7 +464,6 @@ impl Image {
                         TiffUnsupportedError::FloatingPointPredictor(color_type),
                     ));
                 }
-                Predictor::__NonExhaustive => unreachable!(),
             },
             (type_, _) => {
                 return Err(TiffError::UnsupportedError(

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -429,7 +429,6 @@ fn fix_endianness_and_predict(
                 _ => unreachable!("Caller should have validated arguments. Please file a bug."),
             }
         }
-        Predictor::__NonExhaustive => unreachable!(),
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -43,6 +43,7 @@ pub enum TiffError {
 /// The list of variants may grow to incorporate errors of future features. Matching against this
 /// exhaustively is not covered by interface stability guarantees.
 #[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
 pub enum TiffFormatError {
     TiffSignatureNotFound,
     TiffSignatureInvalid,
@@ -68,9 +69,6 @@ pub enum TiffFormatError {
     RequiredTagEmpty(Tag),
     StripTileTagConflict,
     CycleInOffsets,
-    #[doc(hidden)]
-    /// Do not match against this variant. It may get removed.
-    __NonExhaustive,
 }
 
 impl fmt::Display for TiffFormatError {
@@ -121,7 +119,6 @@ impl fmt::Display for TiffFormatError {
             RequiredTagEmpty(ref val) => write!(fmt, "Required tag {:?} was empty.", val),
             StripTileTagConflict => write!(fmt, "File should contain either (StripByteCounts and StripOffsets) or (TileByteCounts and TileOffsets), other combination was found."),
             CycleInOffsets => write!(fmt, "File contained a cycle in the list of IFDs"),
-            __NonExhaustive => unreachable!(),
         }
     }
 }
@@ -135,6 +132,7 @@ impl fmt::Display for TiffFormatError {
 /// The list of variants may grow. Matching against this exhaustively is not covered by interface
 /// stability guarantees.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[non_exhaustive]
 pub enum TiffUnsupportedError {
     FloatingPointPredictor(ColorType),
     HorizontalPredictor(ColorType),
@@ -148,9 +146,6 @@ pub enum TiffUnsupportedError {
     UnsupportedBitsPerChannel(u8),
     UnsupportedPlanarConfig(Option<PlanarConfiguration>),
     UnsupportedDataType,
-    #[doc(hidden)]
-    /// Do not match against this variant. It may get removed.
-    __NonExhaustive,
 }
 
 impl fmt::Display for TiffUnsupportedError {
@@ -196,7 +191,6 @@ impl fmt::Display for TiffUnsupportedError {
                 write!(fmt, "Unsupported planar configuration “{:?}”.", config)
             }
             UnsupportedDataType => write!(fmt, "Unsupported data type."),
-            __NonExhaustive => unreachable!(),
         }
     }
 }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -9,11 +9,9 @@ macro_rules! tags {
     } => {
         $( #[$enum_attr] )*
         #[derive(Clone, Copy, PartialEq, Eq, Debug, Hash)]
+        #[non_exhaustive]
         pub enum $name {
             $($(#[$ident_attr])* $tag,)*
-            // FIXME: switch to non_exhaustive once stabilized and compiler requirement new enough
-            #[doc(hidden)]
-            __NonExhaustive,
             $(
                 #[doc = $unknown_doc]
                 Unknown($ty),
@@ -34,7 +32,6 @@ macro_rules! tags {
                 match *self {
                     $( $name::$tag => $val, )*
                     $( $name::Unknown(n) => { $unknown_doc; n }, )*
-                    $name::__NonExhaustive => unreachable!(),
                 }
             }
         }


### PR DESCRIPTION
Remove some remaining `__NonExhaustive` patterns that are no longer required with the current MSRV.

Factored from the release PR #187 .