### PR TITLE
Fix read in packbits decoder

### DIFF
--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -384,23 +384,23 @@ impl<R: Read> Read for PackBitsReader<R> {
         }
 
         let length = buf.len().min(self.count);
-        match self.state {
-            PackBitsReaderState::Literal => {
-                self.reader.read(&mut buf[..length])?;
-            }
+        let actual = match self.state {
+            PackBitsReaderState::Literal => self.reader.read(&mut buf[..length])?,
             PackBitsReaderState::Repeat { value } => {
                 for b in &mut buf[..length] {
                     *b = value;
                 }
+
+                length
             }
             PackBitsReaderState::Header => unreachable!(),
-        }
+        };
 
-        self.count -= length;
+        self.count -= actual;
         if self.count == 0 {
             self.state = PackBitsReaderState::Header;
         }
-        return Ok(length);
+        return Ok(actual);
     }
 }
 


### PR DESCRIPTION
This assumed that a `read` would succeed for the full length, thus interpreting in a subsequent call some data bits as a header.

For instance, consider 77 bytes of literal were left and a buffer of 1024 bytes was provided. Then the `read` call might return 60 which was ignored and assumed to be 77. Thus the next 17 bytes of literal data were instead interpreted as a header due to setting `self.count` to 0.

Closes: #192 