### PR TITLE
Fix capacity overflow in JpegReader

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -458,6 +458,7 @@ impl Image {
         output_width: usize,
         byte_order: ByteOrder,
         chunk_index: u32,
+        limits: &Limits,
     ) -> TiffResult<()> {
         // Validate that the provided buffer is of the expected type.
         let color_type = self.colortype()?;
@@ -511,6 +512,9 @@ impl Image {
                 .ok_or(TiffError::FormatError(
                     TiffFormatError::InconsistentSizesEncountered,
                 ))?;
+        if *compressed_bytes > limits.intermediate_buffer_size as u64 {
+            return Err(TiffError::LimitsExceeded);
+        }
 
         let byte_len = buffer.byte_len();
         let compression_method = self.compression_method;

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1042,6 +1042,7 @@ impl<R: Read + Seek> Decoder<R> {
             output_width,
             byte_order,
             chunk_index,
+            &self.limits,
         )?;
 
         Ok(())
@@ -1168,6 +1169,7 @@ impl<R: Read + Seek> Decoder<R> {
                 width as usize,
                 byte_order,
                 chunk as u32,
+                &self.limits,
             )?;
         }
 


### PR DESCRIPTION
Hi!  
I've been fuzzing image-rs crate with [AFL++](https://github.com/AFLplusplus/AFLplusplus) using [this fuzz target](https://github.com/ispras/oss-sydr-fuzz/blob/master/projects/image-rs/fuzz-afl/fuzzers/fuzz_tiff.rs) and found a capacity overflow. I think it is better not to panic if we couldn't allocate memory. So, I tried to fix this case.
P.S. If it is interesting I could create a PR for adding AFL++ fuzz targets to image-rs.