### PR TITLE
Don't panic when parsing metadata when custom compression is used

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -109,8 +109,7 @@ impl Image {
         // Try to parse both the compression method and the number, format, and bits of the included samples.
         // If they are not explicitly specified, those tags are reset to their default values and not carried from previous images.
         let compression_method = match tag_reader.find_tag(Tag::Compression)? {
-            Some(val) => CompressionMethod::from_u16(val.into_u16()?)
-                .ok_or(TiffUnsupportedError::UnknownCompressionMethod)?,
+            Some(val) => CompressionMethod::from_u16_exhaustive(val.into_u16()?),
             None => CompressionMethod::None,
         };
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -172,7 +172,7 @@ pub enum Type(u16) {
 tags! {
 /// See [TIFF compression tags](https://www.awaresystems.be/imaging/tiff/tifftags/compression.html)
 /// for reference.
-pub enum CompressionMethod(u16) {
+pub enum CompressionMethod(u16) unknown("A custom compression method") {
     None = 1,
     Huffman = 2,
     Fax3 = 3,


### PR DESCRIPTION
Some microscopy file types, such as `.svs` (https://openslide.org/formats/aperio/) are essentially .tif files, with custom tags. I wanted to read in the metadata (width, height etc.), but this failed due to the file using a custom compression scheme (JPEG2000) that is not supported in the `image-tiff` library/.tif specification.

This PR simply adds in the ability to read in custom compression schemes and therefore also the metadata, without an error occuring.