### PR TITLE
Add Clone to Decoder

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -10,12 +10,12 @@ use crate::{ColorType, TiffError, TiffFormatError, TiffResult, TiffUnsupportedEr
 use std::io::{self, Cursor, Read, Seek};
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct StripDecodeState {
     pub rows_per_strip: u32,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 /// Computed values useful for tile decoding
 pub(crate) struct TileAttributes {
     pub image_width: usize,
@@ -58,7 +58,7 @@ impl TileAttributes {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) struct Image {
     pub ifd: Option<Directory>,
     pub width: u32,

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -293,7 +293,7 @@ impl Default for Limits {
 /// The representation of a TIFF decoder
 ///
 /// Currently does not support decoding of interlaced images
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Decoder<R>
 where
     R: Read + Seek,

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -257,7 +257,7 @@ impl<R: Read> Read for PackBitsReader<R> {
 ///
 
 /// Reader that is aware of the byte order.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct SmartReader<R>
 where
     R: Read,


### PR DESCRIPTION
Added clone to image-tiff, allowing the Decoder to be cloned and re-used.

Useful for Tiffs located on remote storage, without needing decoding.