### PR TITLE
Read Byte as u8, SignedByte as i8

### DIFF
--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -437,7 +437,7 @@ impl Entry {
             // 2b: the value is at most 4 bytes or doesn't fit in the offset field.
             return Ok(match self.type_ {
                 Type::BYTE => Byte(self.offset[0]),
-                Type::SBYTE => Signed(i32::from(self.offset[0] as i8)),
+                Type::SBYTE => SignedByte(i8::from(self.offset[0] as i8)),
                 Type::UNDEFINED => Byte(self.offset[0]),
                 Type::SHORT => Unsigned(u32::from(self.r(bo).read_u16()?)),
                 Type::SSHORT => Signed(i32::from(self.r(bo).read_i16()?)),

--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -56,6 +56,7 @@ impl Value {
 
     pub fn into_u16(self) -> TiffResult<u16> {
         match self {
+            Byte(val) => Ok(val.into()),
             Short(val) => Ok(val),
             Unsigned(val) => Ok(u16::try_from(val)?),
             UnsignedBig(val) => Ok(u16::try_from(val)?),
@@ -79,6 +80,7 @@ impl Value {
 
     pub fn into_u32(self) -> TiffResult<u32> {
         match self {
+            Byte(val) => Ok(val.into()),
             Short(val) => Ok(val.into()),
             Unsigned(val) => Ok(val),
             UnsignedBig(val) => Ok(u32::try_from(val)?),
@@ -104,6 +106,7 @@ impl Value {
 
     pub fn into_u64(self) -> TiffResult<u64> {
         match self {
+            Byte(val) => Ok(val.into()),
             Short(val) => Ok(val.into()),
             Unsigned(val) => Ok(val.into()),
             UnsignedBig(val) => Ok(val),
@@ -163,6 +166,7 @@ impl Value {
                 }
                 Ok(new_vec)
             }
+            Byte(val) => Ok(vec![val.into()]),
             Unsigned(val) => Ok(vec![val]),
             UnsignedBig(val) => Ok(vec![u32::try_from(val)?]),
             Rational(numerator, denominator) => Ok(vec![numerator, denominator]),
@@ -204,6 +208,7 @@ impl Value {
                 }
                 Ok(new_vec)
             }
+            Byte(val) => Ok(vec![val.into()]),
             Short(val) => Ok(vec![val]),
             val => Err(TiffError::FormatError(
                 TiffFormatError::UnsignedIntegerExpected(val),
@@ -285,6 +290,7 @@ impl Value {
                 }
                 Ok(new_vec)
             }
+            Byte(val) => Ok(vec![val.into()]),
             Unsigned(val) => Ok(vec![val.into()]),
             UnsignedBig(val) => Ok(vec![val]),
             Rational(numerator, denominator) => Ok(vec![numerator.into(), denominator.into()]),
@@ -430,7 +436,7 @@ impl Entry {
 
             // 2b: the value is at most 4 bytes or doesn't fit in the offset field.
             return Ok(match self.type_ {
-                Type::BYTE => Unsigned(u32::from(self.offset[0])),
+                Type::BYTE => Byte(self.offset[0]),
                 Type::SBYTE => Signed(i32::from(self.offset[0] as i8)),
                 Type::UNDEFINED => Byte(self.offset[0]),
                 Type::SHORT => Unsigned(u32::from(self.r(bo).read_u16()?)),


### PR DESCRIPTION
Previously, Byte values were read incorrectly as `u32` instead of `u8`, and SignedShort values were read incorrectly as `i32` instead of `i8`.

This PR does the following:
- Correctly cast `Type::BYTE` as u8 values, including in `into_u16`, `into_u32`, `into_u64` methods.
- Correctly cast `Type::SBYTE` as i8 values

Similar to #235, resolves some inconsistencies raised in #204.