### PR TITLE
Bump MSRV from 1.61.0 to 1.70.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "2"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`
-rust-version = "1.61.0"
+rust-version = "1.70.0"
 
 license = "MIT"
 description = "TIFF decoding and encoding library in pure Rust"


### PR DESCRIPTION
MSRV bump was accidentally reverted in https://github.com/image-rs/image-tiff/pull/257/commits/652721eddd2e626d36a1a7feaa7f294950489a82 / #257 and not reinstated.

Have verified using `cargo msrv find` that minimum supported version is indeed `1.70.0`. Output from `cargo msrv list`:

```
  [Meta]   cargo-msrv 0.18.3

  ╭────────┬────────────────────────────────────────────────────────╮
  │ MSRV   │ Dependency                                             │
  ├────────┼────────────────────────────────────────────────────────┤
  │ 1.70.0 │ tiff, half                                             │
  ├────────┼────────────────────────────────────────────────────────┤
  │ 1.67.0 │ flate2                                                 │
  ├────────┼────────────────────────────────────────────────────────┤
  │ 1.61.0 │ jpeg-decoder                                           │
  ├────────┼────────────────────────────────────────────────────────┤
  │        │ weezl, crunchy, cfg-if, miniz_oxide, crc32fast, adler2 │
  ╰────────┴────────────────────────────────────────────────────────╯
```

Note: since there isn't a Cargo.lock file in this repo, I needed to pin `half = { version = "=2.4.1" }` in the Cargo.toml to ensure the correct MSRV of 1.70.0 was picked up, otherwise `half=2.5.0` would result in an MSRV of 1.85.0.