### PR TITLE
Switch to zune-jpeg

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: ["1.70.0", stable, beta, nightly]
+        rust: ["1.74.0", stable, beta, nightly]
     steps:
     - uses: actions/checkout@v2
 
     - uses: dtolnay/rust-toolchain@nightly
-      if: ${{ matrix.rust == '1.70.0' }}
+      if: ${{ matrix.rust == '1.74.0' }}
     - name: Generate Cargo.lock with minimal-version dependencies
-      if: ${{ matrix.rust == '1.70.0' }}
+      if: ${{ matrix.rust == '1.74.0' }}
       run: cargo -Zminimal-versions generate-lockfile
 
     - uses: dtolnay/rust-toolchain@v1
@@ -29,7 +29,7 @@ jobs:
     - name: build
       run: cargo build -v
     - name: test
-      if: ${{ matrix.rust != '1.70.0' }}
+      if: ${{ matrix.rust != '1.74.0' }}
       run: cargo test -v && cargo doc -v
 
   rustfmt:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 resolver = "2"
 
 # note: when changed, also update test runner in `.github/workflows/rust.yml`
-rust-version = "1.70.0"
+rust-version = "1.74.0"
 
 license = "MIT"
 description = "TIFF decoding and encoding library in pure Rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 [dependencies]
 half = { version = "2.4.1" }
 weezl = "0.1.0"
-jpeg = { package = "jpeg-decoder", version = "0.3.0", default-features = false }
+zune-jpeg = "0.4.11"
 flate2 = "1.0.20"
 zstd = { version = "0.13", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 [dependencies]
 half = { version = "2.4.1" }
 weezl = "0.1.0"
-zune-jpeg = "0.4.11"
+zune-jpeg = "0.4.16"
 flate2 = "1.0.20"
 zstd = { version = "0.13", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ exclude = ["tests/images/*", "tests/fuzz_images/*"]
 [dependencies]
 half = { version = "2.4.1" }
 weezl = "0.1.0"
-zune-jpeg = "0.4.16"
+zune-jpeg = "0.4.17"
 flate2 = "1.0.20"
 zstd = { version = "0.13", optional = true }
 quick-error = "2.0.1"

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -448,6 +448,7 @@ impl Image {
                 decoder.set_options(options);
 
                 let data = decoder.decode()?;
+
                 Box::new(Cursor::new(data))
             }
             method => {

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -423,13 +423,16 @@ impl Image {
                 let mut options: zune_core::options::DecoderOptions = Default::default();
                 match photometric_interpretation {
                     PhotometricInterpretation::RGB => {
-                        options = options.jpeg_set_out_colorspace(zune_core::colorspace::ColorSpace::RGB);
+                        options =
+                            options.jpeg_set_out_colorspace(zune_core::colorspace::ColorSpace::RGB);
                     }
                     PhotometricInterpretation::CMYK => {
-                        options = options.jpeg_set_out_colorspace(zune_core::colorspace::ColorSpace::CMYK);
+                        options = options
+                            .jpeg_set_out_colorspace(zune_core::colorspace::ColorSpace::CMYK);
                     }
                     PhotometricInterpretation::YCbCr => {
-                        options = options.jpeg_set_out_colorspace(zune_core::colorspace::ColorSpace::YCbCr);
+                        options = options
+                            .jpeg_set_out_colorspace(zune_core::colorspace::ColorSpace::YCbCr);
                     }
                     PhotometricInterpretation::WhiteIsZero
                     | PhotometricInterpretation::BlackIsZero

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,15 +1,15 @@
 use std::io;
 use std::str;
 use std::string;
+
 use quick_error::quick_error;
+use weezl::LzwError;
 
 use crate::decoder::ChunkType;
 use crate::tags::{
     CompressionMethod, PhotometricInterpretation, PlanarConfiguration, SampleFormat, Tag,
 };
 use crate::ColorType;
-
-use weezl::LzwError;
 
 quick_error! {
     /// Tiff error kinds.

--- a/src/error.rs
+++ b/src/error.rs
@@ -6,15 +6,13 @@ use std::str;
 use std::string;
 use std::sync::Arc;
 
-use jpeg::UnsupportedFeature;
-
 use crate::decoder::{ifd::Value, ChunkType};
 use crate::tags::{
     CompressionMethod, PhotometricInterpretation, PlanarConfiguration, SampleFormat, Tag,
 };
 use crate::ColorType;
 
-use crate::weezl::LzwError;
+use weezl::LzwError;
 
 /// Tiff error kinds.
 #[derive(Debug)]
@@ -166,7 +164,6 @@ pub enum TiffUnsupportedError {
     UnsupportedPlanarConfig(Option<PlanarConfiguration>),
     UnsupportedDataType,
     UnsupportedInterpretation(PhotometricInterpretation),
-    UnsupportedJpegFeature(UnsupportedFeature),
     MisalignedTileBoundaries,
 }
 
@@ -222,9 +219,6 @@ impl fmt::Display for TiffUnsupportedError {
                     "Unsupported photometric interpretation \"{:?}\".",
                     interpretation
                 )
-            }
-            UnsupportedJpegFeature(ref unsupported_feature) => {
-                write!(fmt, "Unsupported JPEG feature {:?}", unsupported_feature)
             }
             MisalignedTileBoundaries => write!(fmt, "Tile rows are not aligned to byte boundaries"),
         }
@@ -360,11 +354,11 @@ impl From<LzwError> for TiffError {
 
 #[derive(Debug, Clone)]
 pub struct JpegDecoderError {
-    inner: Arc<jpeg::Error>,
+    inner: Arc<zune_jpeg::errors::DecodeErrors>,
 }
 
 impl JpegDecoderError {
-    fn new(error: jpeg::Error) -> Self {
+    fn new(error: zune_jpeg::errors::DecodeErrors) -> Self {
         Self {
             inner: Arc::new(error),
         }
@@ -389,8 +383,8 @@ impl From<JpegDecoderError> for TiffError {
     }
 }
 
-impl From<jpeg::Error> for TiffError {
-    fn from(error: jpeg::Error) -> Self {
+impl From<zune_jpeg::errors::DecodeErrors> for TiffError {
+    fn from(error: zune_jpeg::errors::DecodeErrors) -> Self {
         JpegDecoderError::new(error).into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,6 @@
 //! # Related Links
 //! * <https://web.archive.org/web/20210108073850/https://www.adobe.io/open/standards/TIFF.html> - The TIFF specification
 
-extern crate jpeg;
-extern crate weezl;
-
 mod bytecast;
 pub mod decoder;
 pub mod encoder;


### PR DESCRIPTION
This switches the jpeg decoder to match the one used in the main `image` crate.

MSRV bump needed to pull in: https://github.com/rust-lang/rust/pull/113126