### PR TITLE
Let status badge reflect main workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # image-tiff
-[![Build Status](https://github.com/image-rs/image-tiff/workflows/Rust%20CI/badge.svg)](https://github.com/image-rs/image-tiff/actions)
+[![Build Status](https://github.com/image-rs/image-tiff/actions/workflows/rust.yml/badge.svg?branch=main)](https://github.com/image-rs/image-tiff/actions)
 [![Documentation](https://docs.rs/tiff/badge.svg)](https://docs.rs/tiff)
 [![Further crate info](https://img.shields.io/crates/v/tiff.svg)](https://crates.io/crates/tiff)
 


### PR DESCRIPTION
The previous link would list the latest of _all_ workflow runs, including workflows triggered by open pull requests no matter their status and whether they are approved, etc. Let's keep it to the status of the main branch which may be released.