### PR TITLE
Seek to independent IFD sequence in decoding

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -85,6 +85,18 @@ impl Image {
         decoder: &mut ValueReader<R>,
         ifd: Directory,
     ) -> TiffResult<Image> {
+        let img = Self::from_ref(decoder, &ifd)?;
+
+        Ok(Image {
+            ifd: Some(ifd),
+            ..img
+        })
+    }
+
+    pub(crate) fn from_ref<R: Read + Seek>(
+        decoder: &mut ValueReader<R>,
+        ifd: &Directory,
+    ) -> TiffResult<Image> {
         let mut tag_reader = TagReader { decoder, ifd: &ifd };
 
         let width = tag_reader.require_tag(Tag::ImageWidth)?.into_u32()?;
@@ -287,7 +299,7 @@ impl Image {
         };
 
         Ok(Image {
-            ifd: Some(ifd),
+            ifd: None,
             width,
             height,
             bits_per_sample: bits_per_sample[0],

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -21,7 +21,7 @@ mod stream;
 mod tag_reader;
 
 /// Result of a decoding process
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum DecodingResult {
     /// A vector of unsigned bytes
     U8(Vec<u8>),
@@ -574,69 +574,80 @@ impl<R: Read + Seek> Decoder<R> {
 
     /// Loads the IFD at the specified index in the list, if one exists
     pub fn seek_to_image(&mut self, ifd_index: usize) -> TiffResult<()> {
-        // Check whether we have seen this IFD before, if so then the index will be less than the length of the list of ifd offsets
-        if ifd_index >= self.ifd_offsets.len() {
-            // We possibly need to load in the next IFD
-            if self.next_ifd.is_none() {
-                self.current_ifd = None;
-
-                return Err(TiffError::FormatError(
-                    TiffFormatError::ImageFileDirectoryNotFound,
-                ));
-            }
-
-            loop {
-                // Follow the list until we find the one we want, or we reach the end, whichever happens first
-                let ifd = self.next_ifd()?;
-
-                if ifd.next().is_none() {
-                    break;
-                }
-
-                if ifd_index < self.ifd_offsets.len() {
-                    break;
-                }
-            }
-        }
-
-        // If the index is within the list of ifds then we can load the selected image/IFD
-        if let Some(ifd_offset) = self.ifd_offsets.get(ifd_index) {
-            let ifd = self.value_reader.read_directory(*ifd_offset)?;
-            self.next_ifd = ifd.next();
-            self.current_ifd = Some(*ifd_offset);
-            self.image = Image::from_reader(&mut self.value_reader, ifd)?;
-
-            Ok(())
-        } else {
-            Err(TiffError::FormatError(
-                TiffFormatError::ImageFileDirectoryNotFound,
-            ))
-        }
+        let ifd = self.seek_to_directory(ifd_index)?;
+        self.image = Image::from_reader(&mut self.value_reader, ifd)?;
+        Ok(())
     }
 
-    /// Start the chain of IFDs from a new location.
+    fn seek_to_directory(&mut self, ifd_index: usize) -> TiffResult<Directory> {
+        if ifd_index < self.ifd_offsets.len() {
+            // If the index is within the list of ifds then we can load the selected image/IFD
+            let ifd_offset = self.ifd_offsets[ifd_index];
+            let ifd = self.value_reader.read_directory(ifd_offset)?;
+
+            self.next_ifd = ifd.next();
+            self.current_ifd = Some(ifd_offset);
+
+            return Ok(ifd);
+        }
+
+        // Follow the list until we find the one we want, or we reach the end, whichever happens
+        // first. How many IFDs to read only for their `next` field?
+        let step_over = self.ifd_offsets.len() - ifd_index;
+
+        for _ in 0..step_over {
+            // FIXME: for optimization we only need to read the offset of this one, not its whole
+            // data. However on buffered files this should be a rather small difference unless
+            // you're traversing a lot of directories.
+
+            // Detecting an end-of-file is done by `next_ifd`. We ignore the IFD itself (but not
+            // via an ignore pattern to avoid silencing must_use accidentally).
+            self.next_ifd()?;
+        }
+
+        // self.next_ifd, self.current_ifd will be setup by `next_ifd`.
+        self.next_ifd()
+    }
+
+    /// Start the chain of image directories from a new location.
     ///
-    /// This enters a new chain of image file descriptors with the indicated IFD as the new root
-    /// (similar to the file having its initial offset at the given IFD). After this call,
-    /// [`Self::seek_to_image`] works relative to the new root.
+    /// This enters a new chain of image file directories with the indicated offset as the new root
+    /// (similar to the file having its initial offset at the given IFD position). After this call,
+    /// [`Self::seek_to_image`] has the new root at index `0` and works relative to the new root.
     ///
-    /// Note that this is not atomic. If the function returns an error, the decoder is left in an
-    /// intermediate state where it does not point to any image. A valid state can be recovered by
-    /// calling [`Self::restart_ifds`] with a valid offset and a successful seek. Explicit reads
-    /// will still work.
-    pub fn restart_ifds(&mut self, offset: IfdPointer) -> TiffResult<()> {
+    /// This is not atomic with regards to errors. If the function returns an error, the decoder is
+    /// left in an intermediate state where it does not point to any image. A valid state can be
+    /// recovered by calling [`Self::restart_at_image`] with a valid offset and a successful seek.
+    pub fn restart_at_image(&mut self, offset: IfdPointer) -> TiffResult<()> {
+        let ifd = self.restart_at_offset(offset)?;
+        self.image = Image::from_reader(&mut self.value_reader, ifd)?;
+        Ok(())
+    }
+
+    /// Start the chain of non-image directories from a new location.
+    ///
+    /// See [`Self::restart_at_image`] for details, except this method does not attempt to
+    /// interpret the directory in the sequence as an image. Instead, it may be used to read a
+    /// sequence of auxiliary IFDs that are not necessarily images. For instance, a directory
+    /// referred to in the SubIfd tag may be a thumbnail
+    pub fn restart_at_directory(&mut self, offset: IfdPointer) -> TiffResult<Directory> {
+        self.restart_at_offset(offset)
+    }
+
+    fn restart_at_offset(&mut self, offset: IfdPointer) -> TiffResult<Directory> {
         self.ifd_offsets.clear();
         self.ifd_offsets.push(offset);
 
         self.next_ifd = Some(offset);
         self.current_ifd = None;
 
-        self.next_ifd()?;
-        Ok(())
+        self.next_ifd()
     }
 
     fn next_ifd(&mut self) -> TiffResult<Directory> {
         let Some(next_ifd) = self.next_ifd.take() else {
+            self.current_ifd = None;
+
             return Err(TiffError::FormatError(
                 TiffFormatError::ImageFileDirectoryNotFound,
             ));
@@ -664,6 +675,30 @@ impl<R: Read + Seek> Decoder<R> {
     pub fn next_image(&mut self) -> TiffResult<()> {
         let ifd = self.next_ifd()?;
         self.image = Image::from_reader(&mut self.value_reader, ifd)?;
+        Ok(())
+    }
+
+    /// Read the next directory without interpreting it as an image.
+    ///
+    /// If there is no further image in the TIFF file a format error is returned. To determine
+    /// whether there are more images call `TIFFDecoder::more_directories` instead.
+    pub fn next_directory(&mut self) -> TiffResult<Directory> {
+        self.next_ifd()
+    }
+
+    /// Interpret the current directory as an image.
+    ///
+    /// This method is used after having called [`Self::restart_at`] or [`Self::next_directory`] to
+    /// iterate the sequence of image file directories, having read a directory without having read
+    /// its tags as image data.
+    pub fn current_directory_as_image(&mut self) -> TiffResult<()> {
+        let current_ifd = self.current_ifd.ok_or(TiffError::FormatError(
+            TiffFormatError::ImageFileDirectoryNotFound,
+        ))?;
+
+        let ifd = self.read_directory(current_ifd)?;
+        self.image = Image::from_reader(&mut self.value_reader, ifd)?;
+
         Ok(())
     }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -614,6 +614,27 @@ impl<R: Read + Seek> Decoder<R> {
         }
     }
 
+    /// Start the chain of IFDs from a new location.
+    ///
+    /// This enters a new chain of image file descriptors with the indicated IFD as the new root
+    /// (similar to the file having its initial offset at the given IFD). After this call,
+    /// [`Self::seek_to_image`] works relative to the new root.
+    ///
+    /// Note that this is not atomic. If the function returns an error, the decoder is left in an
+    /// intermediate state where it does not point to any image. A valid state can be recovered by
+    /// calling [`Self::restart_ifds`] with a valid offset and a successful seek. Explicit reads
+    /// will still work.
+    pub fn restart_ifds(&mut self, offset: IfdPointer) -> TiffResult<()> {
+        self.ifd_offsets.clear();
+        self.ifd_offsets.push(offset);
+
+        self.next_ifd = Some(offset);
+        self.current_ifd = None;
+
+        self.next_ifd()?;
+        Ok(())
+    }
+
     fn next_ifd(&mut self) -> TiffResult<Directory> {
         let Some(next_ifd) = self.next_ifd.take() else {
             return Err(TiffError::FormatError(

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -270,6 +270,10 @@ where
     ifd_offsets: Vec<IfdPointer>,
     /// Map from the ifd into the `ifd_offsets` ordered list.
     seen_ifds: cycles::IfdCycles,
+    /// The directory, if we have not yet read it as an image.
+    /// This is prioritized _over_ the image. Hence it must _not_ be set if we are currently
+    /// reading a true image IFD that is instead stored in the `image` attribute.
+    non_image_ifd: Option<Directory>,
     image: Image,
 }
 
@@ -545,6 +549,7 @@ impl<R: Read + Seek> Decoder<R> {
                 chunk_offsets: Vec::new(),
                 chunk_bytes: Vec::new(),
             },
+            non_image_ifd: None,
         };
         decoder.next_image()?;
         Ok(decoder)
@@ -575,6 +580,7 @@ impl<R: Read + Seek> Decoder<R> {
     /// Loads the IFD at the specified index in the list, if one exists
     pub fn seek_to_image(&mut self, ifd_index: usize) -> TiffResult<()> {
         let ifd = self.seek_to_directory(ifd_index)?;
+        self.non_image_ifd = None;
         self.image = Image::from_reader(&mut self.value_reader, ifd)?;
         Ok(())
     }
@@ -620,6 +626,7 @@ impl<R: Read + Seek> Decoder<R> {
     /// recovered by calling [`Self::restart_at_image`] with a valid offset and a successful seek.
     pub fn restart_at_image(&mut self, offset: IfdPointer) -> TiffResult<()> {
         let ifd = self.restart_at_offset(offset)?;
+        self.non_image_ifd = None;
         self.image = Image::from_reader(&mut self.value_reader, ifd)?;
         Ok(())
     }
@@ -630,8 +637,10 @@ impl<R: Read + Seek> Decoder<R> {
     /// interpret the directory in the sequence as an image. Instead, it may be used to read a
     /// sequence of auxiliary IFDs that are not necessarily images. For instance, a directory
     /// referred to in the SubIfd tag may be a thumbnail
-    pub fn restart_at_directory(&mut self, offset: IfdPointer) -> TiffResult<Directory> {
-        self.restart_at_offset(offset)
+    pub fn restart_at_directory(&mut self, offset: IfdPointer) -> TiffResult<()> {
+        let ifd = self.restart_at_offset(offset)?;
+        self.non_image_ifd = Some(ifd);
+        Ok(())
     }
 
     fn restart_at_offset(&mut self, offset: IfdPointer) -> TiffResult<Directory> {
@@ -647,6 +656,7 @@ impl<R: Read + Seek> Decoder<R> {
     fn next_ifd(&mut self) -> TiffResult<Directory> {
         let Some(next_ifd) = self.next_ifd.take() else {
             self.current_ifd = None;
+            self.non_image_ifd = None;
 
             return Err(TiffError::FormatError(
                 TiffFormatError::ImageFileDirectoryNotFound,
@@ -674,6 +684,7 @@ impl<R: Read + Seek> Decoder<R> {
     /// To determine whether there are more images call `TIFFDecoder::more_images` instead.
     pub fn next_image(&mut self) -> TiffResult<()> {
         let ifd = self.next_ifd()?;
+        self.non_image_ifd = None;
         self.image = Image::from_reader(&mut self.value_reader, ifd)?;
         Ok(())
     }
@@ -682,8 +693,10 @@ impl<R: Read + Seek> Decoder<R> {
     ///
     /// If there is no further image in the TIFF file a format error is returned. To determine
     /// whether there are more images call `TIFFDecoder::more_directories` instead.
-    pub fn next_directory(&mut self) -> TiffResult<Directory> {
-        self.next_ifd()
+    pub fn next_directory(&mut self) -> TiffResult<()> {
+        let ifd = self.next_ifd()?;
+        self.non_image_ifd = Some(ifd);
+        Ok(())
     }
 
     /// Interpret the current directory as an image.
@@ -696,8 +709,15 @@ impl<R: Read + Seek> Decoder<R> {
             TiffFormatError::ImageFileDirectoryNotFound,
         ))?;
 
-        let ifd = self.read_directory(current_ifd)?;
-        self.image = Image::from_reader(&mut self.value_reader, ifd)?;
+        if let Some(ifd) = &self.non_image_ifd {
+            self.image = Image::from_ref(&mut self.value_reader, ifd)?;
+            // Definitely sets an IFD but this works without unwraps.
+            self.image.ifd = self.non_image_ifd.take();
+        } else {
+            // Probably re-reading an image but that's fine.
+            let ifd = self.read_directory(current_ifd)?;
+            self.image = Image::from_reader(&mut self.value_reader, ifd)?;
+        }
 
         Ok(())
     }
@@ -1055,11 +1075,22 @@ impl<R: Read + Seek> Decoder<R> {
     }
 
     /// Get the IFD decoder for our current image IFD.
-    fn image_ifd(&mut self) -> IfdDecoder<'_> {
+    fn current_directory_ifd(&mut self) -> IfdDecoder<'_> {
+        // Special fallback. We do not want to error handle not having read a current directory, in
+        // particular as the behavior having a directory without tags will produce these errors
+        // anyways (most likely). Note that an empty directory is invalid in a TIFF.
+        static NO_IFD: Directory = Directory::empty();
+
+        let ifd = self
+            .non_image_ifd
+            .as_ref()
+            .or_else(|| self.image.ifd.as_ref())
+            .unwrap_or(&NO_IFD);
+
         IfdDecoder {
             inner: tag_reader::TagReader {
                 decoder: &mut self.value_reader,
-                ifd: self.image.ifd.as_ref().unwrap(),
+                ifd,
             },
         }
     }
@@ -1100,25 +1131,25 @@ impl<R: Read + Seek> Decoder<R> {
     /// Tries to retrieve a tag from the current image directory.
     /// Return `Ok(None)` if the tag is not present.
     pub fn find_tag(&mut self, tag: Tag) -> TiffResult<Option<ifd::Value>> {
-        self.image_ifd().find_tag(tag)
+        self.current_directory_ifd().find_tag(tag)
     }
 
     /// Tries to retrieve a tag in the current image directory and convert it to the desired
     /// unsigned type.
     pub fn find_tag_unsigned<T: TryFrom<u64>>(&mut self, tag: Tag) -> TiffResult<Option<T>> {
-        self.image_ifd().find_tag_unsigned(tag)
+        self.current_directory_ifd().find_tag_unsigned(tag)
     }
 
     /// Tries to retrieve a tag from the current image directory and convert it to the desired
     /// unsigned type. Returns an error if the tag is not present.
     pub fn get_tag_unsigned<T: TryFrom<u64>>(&mut self, tag: Tag) -> TiffResult<T> {
-        self.image_ifd().get_tag_unsigned(tag)
+        self.current_directory_ifd().get_tag_unsigned(tag)
     }
 
     /// Tries to retrieve a tag from the current image directory.
     /// Returns an error if the tag is not present
     pub fn get_tag(&mut self, tag: Tag) -> TiffResult<ifd::Value> {
-        self.image_ifd().get_tag(tag)
+        self.current_directory_ifd().get_tag(tag)
     }
 
     pub fn get_tag_u32(&mut self, tag: Tag) -> TiffResult<u32> {
@@ -1173,7 +1204,7 @@ impl<R: Read + Seek> Decoder<R> {
     }
 
     pub fn tag_iter(&mut self) -> impl Iterator<Item = TiffResult<(Tag, ifd::Value)>> + '_ {
-        self.image_ifd().tag_iter()
+        self.current_directory_ifd().tag_iter()
     }
 }
 

--- a/src/directory.rs
+++ b/src/directory.rs
@@ -27,7 +27,7 @@ pub struct Directory {
 }
 
 impl Directory {
-    pub fn empty() -> Self {
+    pub const fn empty() -> Self {
         Directory {
             entries: BTreeMap::new(),
             next_ifd: None,

--- a/tests/subsubifds.rs
+++ b/tests/subsubifds.rs
@@ -123,10 +123,7 @@ fn decode_subifds() {
         loop {
             len += 1;
 
-            let position = decoder.ifd_pointer().unwrap();
-            let ifd = decoder.read_directory(position).unwrap();
-
-            if let Ok(subifd) = decoder.read_directory_tags(&ifd).get_tag(Tag::SubIfd) {
+            if let Ok(subifd) = decoder.get_tag(Tag::SubIfd) {
                 let prelen = subifds.len();
                 subifds.extend(subifd.into_ifd_vec().expect("Failed to decode SubIfd tag"));
                 eprintln!("New roots: {:?}", &subifds[prelen..]);


### PR DESCRIPTION
This adds two capabilities to the encoder:

- `next_directory` to decode a directory without already decoding its contained `image` tags. It only reads a single contiguous range of file data and is thus quite a lot cheaper if only very specific tag values are of interest (or the image is to be skipped). 
- `current_directory_as_image` to manually augment the IFD with its contained image.
- `restart_at_{directory,image}` to setup a new root directory. This can also be used to iterate SubIFDs in arbitrary depth by combining it with `next_directory` and appropriate tag reads.