### PR TITLE
Address compilation warnings in the Nightly channel of Rust

### DIFF
--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -138,7 +138,7 @@ impl DecodingResult {
         }
     }
 
-    pub fn as_buffer(&mut self, start: usize) -> DecodingBuffer {
+    pub fn as_buffer(&mut self, start: usize) -> DecodingBuffer<'_> {
         match *self {
             DecodingResult::U8(ref mut buf) => DecodingBuffer::U8(&mut buf[start..]),
             DecodingResult::U16(ref mut buf) => DecodingBuffer::U16(&mut buf[start..]),

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -198,7 +198,7 @@ impl<W: Write + Seek, K: TiffKind> TiffEncoder<W, K> {
         &mut self,
         width: u32,
         height: u32,
-    ) -> TiffResult<ImageEncoder<W, C, K>> {
+    ) -> TiffResult<ImageEncoder<'_, W, C, K>> {
         let encoder = Self::chain_directory(&mut self.writer, &mut self.last_ifd_chain)?;
         ImageEncoder::new(encoder, width, height, self.compression, self.predictor)
     }

--- a/src/encoder/tiff_value.rs
+++ b/src/encoder/tiff_value.rs
@@ -15,7 +15,7 @@ pub trait TiffValue {
 
     /// Access this value as an contiguous sequence of bytes.
     /// If their is no trivial representation, allocate it on the heap.
-    fn data(&self) -> Cow<[u8]>;
+    fn data(&self) -> Cow<'_, [u8]>;
 
     /// Write this value to a TiffWriter.
     /// While the default implementation will work in all cases, it may require unnecessary allocations.
@@ -34,7 +34,7 @@ impl TiffValue for [u8] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(self)
     }
 }
@@ -47,7 +47,7 @@ impl TiffValue for [i8] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i8_as_ne_bytes(self))
     }
 }
@@ -60,7 +60,7 @@ impl TiffValue for [u16] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u16_as_ne_bytes(self))
     }
 }
@@ -73,7 +73,7 @@ impl TiffValue for [i16] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i16_as_ne_bytes(self))
     }
 }
@@ -86,7 +86,7 @@ impl TiffValue for [u32] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u32_as_ne_bytes(self))
     }
 }
@@ -99,7 +99,7 @@ impl TiffValue for [i32] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i32_as_ne_bytes(self))
     }
 }
@@ -112,7 +112,7 @@ impl TiffValue for [u64] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u64_as_ne_bytes(self))
     }
 }
@@ -125,7 +125,7 @@ impl TiffValue for [i64] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i64_as_ne_bytes(self))
     }
 }
@@ -138,7 +138,7 @@ impl TiffValue for [f32] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         // We write using native endian so this should be safe
         Cow::Borrowed(bytecast::f32_as_ne_bytes(self))
     }
@@ -152,7 +152,7 @@ impl TiffValue for [f64] {
         self.len()
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         // We write using native endian so this should be safe
         Cow::Borrowed(bytecast::f64_as_ne_bytes(self))
     }
@@ -171,7 +171,7 @@ impl TiffValue for u8 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(from_ref(self))
     }
 }
@@ -189,7 +189,7 @@ impl TiffValue for i8 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i8_as_ne_bytes(from_ref(self)))
     }
 }
@@ -207,7 +207,7 @@ impl TiffValue for u16 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u16_as_ne_bytes(from_ref(self)))
     }
 }
@@ -225,7 +225,7 @@ impl TiffValue for i16 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i16_as_ne_bytes(from_ref(self)))
     }
 }
@@ -243,7 +243,7 @@ impl TiffValue for u32 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u32_as_ne_bytes(from_ref(self)))
     }
 }
@@ -261,7 +261,7 @@ impl TiffValue for i32 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i32_as_ne_bytes(from_ref(self)))
     }
 }
@@ -279,7 +279,7 @@ impl TiffValue for u64 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u64_as_ne_bytes(from_ref(self)))
     }
 }
@@ -297,7 +297,7 @@ impl TiffValue for i64 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::i64_as_ne_bytes(from_ref(self)))
     }
 }
@@ -315,7 +315,7 @@ impl TiffValue for f32 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::f32_as_ne_bytes(from_ref(self)))
     }
 }
@@ -333,7 +333,7 @@ impl TiffValue for f64 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::f64_as_ne_bytes(from_ref(self)))
     }
 }
@@ -351,7 +351,7 @@ impl TiffValue for Ifd {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u32_as_ne_bytes(from_ref(&self.0)))
     }
 }
@@ -369,7 +369,7 @@ impl TiffValue for Ifd8 {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Borrowed(bytecast::u64_as_ne_bytes(from_ref(&self.0)))
     }
 }
@@ -388,7 +388,7 @@ impl TiffValue for Rational {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Owned({
             let first_dword = bytecast::u32_as_ne_bytes(from_ref(&self.n));
             let second_dword = bytecast::u32_as_ne_bytes(from_ref(&self.d));
@@ -411,7 +411,7 @@ impl TiffValue for SRational {
         Ok(())
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Owned({
             let first_dword = bytecast::i32_as_ne_bytes(from_ref(&self.n));
             let second_dword = bytecast::i32_as_ne_bytes(from_ref(&self.d));
@@ -438,7 +438,7 @@ impl TiffValue for str {
         }
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         Cow::Owned({
             if self.is_ascii() && !self.bytes().any(|b| b == 0) {
                 let bytes: &[u8] = self.as_bytes();
@@ -462,7 +462,7 @@ impl<T: TiffValue + ?Sized> TiffValue for &'_ T {
         (*self).write(writer)
     }
 
-    fn data(&self) -> Cow<[u8]> {
+    fn data(&self) -> Cow<'_, [u8]> {
         T::data(self)
     }
 }
@@ -484,7 +484,7 @@ macro_rules! impl_tiff_value_for_contiguous_sequence {
                 Ok(())
             }
 
-            fn data(&self) -> Cow<[u8]> {
+            fn data(&self) -> Cow<'_, [u8]> {
                 let mut buf: Vec<u8> = Vec::with_capacity(Self::BYTE_LEN as usize * self.len());
                 for x in self {
                     buf.extend_from_slice(&x.data());


### PR DESCRIPTION
The warnings I'm seeing are:

```
warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/decoder/mod.rs:141:22
    |
141 |     pub fn as_buffer(&mut self, start: usize) -> DecodingBuffer {
    |                      ^^^^^^^^^                   -------------- the same lifetime is hidden here
    |                      |
    |                      the lifetime is elided here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
    = note: `#[warn(mismatched_lifetime_syntaxes)]` on by default
help: use `'_` for type paths
    |
141 |     pub fn as_buffer(&mut self, start: usize) -> DecodingBuffer<'_> {
    |                                                                ++++

warning: hiding a lifetime that's elided elsewhere is confusing
   --> src/encoder/mod.rs:198:9
    |
198 |         &mut self,
    |         ^^^^^^^^^ the lifetime is elided here
...
201 |     ) -> TiffResult<ImageEncoder<W, C, K>> {
    |                     --------------------- the same lifetime is hidden here
    |
    = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
    |
201 |     ) -> TiffResult<ImageEncoder<'_, W, C, K>> {
    |                                  +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/encoder/tiff_value.rs:18:13
   |
18 |     fn data(&self) -> Cow<[u8]>;
   |             ^^^^^     --------- the same lifetime is hidden here
   |             |
   |             the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
18 |     fn data(&self) -> Cow<'_, [u8]>;
   |                           +++

warning: hiding a lifetime that's elided elsewhere is confusing
  --> src/encoder/tiff_value.rs:37:13
   |
37 |     fn data(&self) -> Cow<[u8]> {
   |             ^^^^^     --------- the same lifetime is hidden here
   |             |
   |             the lifetime is elided here
   |
   = help: the same lifetime is referred to in inconsistent ways, making the signature confusing
help: use `'_` for type paths
   |
37 |     fn data(&self) -> Cow<'_, [u8]> {
   |                           +++
```

and more (33 in total).