### PR TITLE
Changelog 0.10.2

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+# Version 0.10.2
+
+Republished 0.10.1, fixing an accidentally removed method (`Decoder::find_tag_unsigned_vec`).
+
 # Version 0.10.1
 
 New features:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiff"
-version = "0.10.1"
+version = "0.10.2"
 edition = "2021"
 resolver = "2"
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -1281,6 +1281,15 @@ impl<R: Read + Seek> Decoder<R> {
         self.image_ifd().find_tag_unsigned(tag)
     }
 
+    /// Tries to retrieve a vector of all a tag's values and convert them to the desired unsigned
+    /// type.
+    pub fn find_tag_unsigned_vec<T: TryFrom<u64>>(
+        &mut self,
+        tag: Tag,
+    ) -> TiffResult<Option<Vec<T>>> {
+        self.image_ifd().find_tag_unsigned_vec(tag)
+    }
+
     /// Tries to retrieve a tag from the current image directory and convert it to the desired
     /// unsigned type. Returns an error if the tag is not present.
     pub fn get_tag_unsigned<T: TryFrom<u64>>(&mut self, tag: Tag) -> TiffResult<T> {


### PR DESCRIPTION
I've already yanked `0.10.1`, apparently I've accidentally moved `find_tag_unsigned_vec` to the new `IfdDecoder` without reproducing its proxy interface in `Decoder` which made that version Semver incompatible. Adding the semver checks as we have in `image` would be neat.