### PR TITLE
Fix type mismatch for reading Lists of Bytes

### DIFF
--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -577,10 +577,10 @@ impl Entry {
             Type::BYTE => self.decode_offset(self.count, bo, bigtiff, limits, reader, |reader| {
                 let mut buf = [0; 1];
                 reader.inner().read_exact(&mut buf)?;
-                Ok(UnsignedBig(u64::from(buf[0])))
+                Ok(Byte(buf[0]))
             }),
             Type::SBYTE => self.decode_offset(self.count, bo, bigtiff, limits, reader, |reader| {
-                Ok(SignedBig(i64::from(reader.read_i8()?)))
+                Ok(SignedByte(reader.read_i8()?))
             }),
             Type::SHORT => self.decode_offset(self.count, bo, bigtiff, limits, reader, |reader| {
                 Ok(Short(reader.read_u16()?))


### PR DESCRIPTION
At the moment when writing Byte strings into tiff metadata sections (like for XMP metadata) and try to read it with this crate, you will find your characters as a Value::UnsignedBig, holding the char value with padding.

This seems wrong and we should instead return actual Value::Bytes.