### PR TITLE
Make fax a default feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ criterion = "0.3.1"
 crc32fast = "1.5"
 
 [features]
-default = ["deflate", "jpeg", "lzw"]
+default = ["deflate", "fax", "jpeg", "lzw"]
 
 # Compression algorithms
 deflate = ["dep:flate2"]


### PR DESCRIPTION
Fax was commonly requested, so let's make it Just Work when tiff crate is used through `image` where it's difficult to fiddle with tiff crate features.