### PR TITLE
Add ICC Lab interpretation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,9 @@ pub enum ColorType {
     /// Pixel is YCbCr
     YCbCr(u8),
 
+    /// Pixel is CIE L*a*b* (ICC LAb)
+    Lab(u8),
+
     /// Pixel has multiple bands/channels
     Multiband { bit_depth: u8, num_samples: u16 },
 }
@@ -58,6 +61,7 @@ impl ColorType {
             | ColorType::CMYK(b)
             | ColorType::CMYKA(b)
             | ColorType::YCbCr(b)
+            | ColorType::Lab(b)
             | ColorType::Multiband { bit_depth: b, .. } => b,
         }
     }
@@ -72,6 +76,7 @@ impl ColorType {
             ColorType::CMYK(_) => 4,
             ColorType::CMYKA(_) => 5,
             ColorType::YCbCr(_) => 3,
+            ColorType::Lab(_) => 3,
             ColorType::Multiband { num_samples, .. } => num_samples,
         }
     }

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -266,6 +266,8 @@ pub enum PhotometricInterpretation(u16) {
     CMYK = 5,
     YCbCr = 6,
     CIELab = 8,
+    IccLab = 9,
+    ItuLab = 10,
 }
 }
 


### PR DESCRIPTION
The CIE Lab interpretation uses heterogeneous samples, and the ITU Lab encoding requires the Tag Decode (433, 0x01B1) which has default values depending on bit depth and convering values into floating points, probably.

See also Photometric Interpretation: <https://web.archive.org/web/20050309053132/http://www.awaresystems.be/imaging/tiff/tifftags/photometricinterpretation.html>
See also Tag Decode: <https://web.archive.org/web/20050309072856/http://www.awaresystems.be/imaging/tiff/tifftags/decode.html>

Closes: #312 