### PR TITLE
Recognize Ycbcr/Chroma subsampling tags

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -740,6 +740,12 @@ impl Image {
         if matches!(color, ColorType::YCbCr(_)) && self.chroma_subsampling != (1, 1) {
             // The JPEG library does upsampling for us and defines its buffers correctly
             // (presumably). All other compression schemes are not supported..
+            //
+            // NOTE: as explained in <fa225e820b96bef35f01bf4685654beeb4a8df0c> we may be better
+            // off supporting this tag by consistently upsampling, not by adjusting the buffer
+            // size. At least as a default this makes more sense and is much more permissive in
+            // case the compression stream disagrees with the tags (we would not have enough / or
+            // the wrong buffer layout if we only asked for subsampled planes in a planar layout).
             if !matches!(self.compression_method, CompressionMethod::ModernJPEG) {
                 return Err(TiffError::UnsupportedError(
                     TiffUnsupportedError::ChromaSubsampling,

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -738,9 +738,13 @@ impl Image {
 
         // Only this color type interprets the tag, which is defined with a default of (2, 2)
         if matches!(color, ColorType::YCbCr(_)) && self.chroma_subsampling != (1, 1) {
-            return Err(TiffError::UnsupportedError(
-                TiffUnsupportedError::ChromaSubsampling,
-            ));
+            // The JPEG library does upsampling for us and defines its buffers correctly
+            // (presumably). All other compression schemes are not supported..
+            if !matches!(self.compression_method, CompressionMethod::ModernJPEG) {
+                return Err(TiffError::UnsupportedError(
+                    TiffUnsupportedError::ChromaSubsampling,
+                ));
+            }
         }
 
         Ok(ReadoutLayout {

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -85,6 +85,7 @@ pub(crate) struct Image {
     pub tile_attributes: Option<TileAttributes>,
     pub chunk_offsets: Vec<u64>,
     pub chunk_bytes: Vec<u64>,
+    pub chroma_subsampling: (u16, u16),
 }
 
 /// Describes how to read a tile-aligned portion of the image.
@@ -275,6 +276,25 @@ impl Image {
             .transpose()?
             .unwrap_or(PlanarConfiguration::Chunky);
 
+        let ycbcr_subsampling = tag_reader.find_tag_uint_vec::<u16>(Tag::ChromaSubsampling)?;
+
+        let chroma_subsampling = if let Some(subsamples) = &ycbcr_subsampling {
+            let [a, b] = subsamples.as_slice() else {
+                return Err(TiffError::FormatError(TiffFormatError::InvalidCountForTag(
+                    Tag::ChromaSubsampling,
+                    subsamples.len(),
+                )));
+            };
+
+            // ImageWidth and ImageLength are constrained to be integer multiples of
+            // YCbCrSubsampleHoriz and YCbCrSubsampleVert respectively. TileWidth and TileLength
+            // have the same constraints. RowsPerStrip must be an integer multiple of
+            // YCbCrSubsampleVert.
+            (*a, *b)
+        } else {
+            (2, 2)
+        };
+
         let planes = match planar_config {
             PlanarConfiguration::Chunky => 1,
             PlanarConfiguration::Planar => samples,
@@ -386,6 +406,7 @@ impl Image {
             tile_attributes,
             chunk_offsets,
             chunk_bytes,
+            chroma_subsampling,
         })
     }
 
@@ -712,6 +733,13 @@ impl Image {
         if chunks_across > 1 && chunk_row_bits % 8 != 0 {
             return Err(TiffError::UnsupportedError(
                 TiffUnsupportedError::MisalignedTileBoundaries,
+            ));
+        }
+
+        // Only this color type interprets the tag, which is defined with a default of (2, 2)
+        if matches!(color, ColorType::YCbCr(_)) && self.chroma_subsampling != (1, 1) {
+            return Err(TiffError::UnsupportedError(
+                TiffUnsupportedError::ChromaSubsampling,
             ));
         }
 

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -860,6 +860,7 @@ impl<R: Read + Seek> Decoder<R> {
                 tile_attributes: None,
                 chunk_offsets: Vec::new(),
                 chunk_bytes: Vec::new(),
+                chroma_subsampling: (2, 2),
             },
         };
         decoder.next_image()?;

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,6 +90,9 @@ quick_error! {
         InvalidTypeForTag {
             display("tag has invalid type")
         }
+        InvalidCountForTag(tag: Tag, len: usize) {
+            display("tag `{tag:?}` with incorrect number of elements ({len}) encountered")
+        }
         StripTileTagConflict {
             display("file should contain either (StripByteCounts and StripOffsets) or (TileByteCounts and TileOffsets), other combination was found")
         }
@@ -155,6 +158,9 @@ quick_error! {
         }
         UnsupportedInterpretation(interpretation: PhotometricInterpretation) {
             display("unsupported photometric interpretation \"{interpretation:?}\"")
+        }
+        ChromaSubsampling {
+            display("chroma subsampling of YCbCr color is unsupported")
         }
         MisalignedTileBoundaries {
             display("tile rows are not aligned to byte boundaries")

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -122,6 +122,11 @@ pub enum Tag(u16) unknown(
     SMaxSampleValue = 341, // TODO add support
     // JPEG
     JPEGTables = 347,
+    // Subsampling
+    #[doc(alias = "YCbCrSubsampling")]
+    ChromaSubsampling = 530, // TODO add support
+    #[doc(alias = "YCbCrPositioning")]
+    ChromaPositioning = 531, // TODO add support
     // GeoTIFF
     ModelPixelScaleTag = 33550, // (SoftDesk)
     ModelTransformationTag = 34264, // (JPL Carto Group)


### PR DESCRIPTION
Note that in the decoder we error _late_ if the information in the tag has at least the right type and is plausible. We only have a problem supporting the buffer layout that would be calculated, iterating over the image itself leaves us in a fully consistent state otherwise.

Also fixes a bug in the encoder where we apparently already have support. The default value for the tag, i.e. its interpretation if absent, [is `(2, 2)`](https://web.archive.org/web/20061207005832/http://www.awaresystems.be/imaging/tiff/tifftags/ycbcrsubsampling.html), which implies that some form of subsampling should be used. Since the samples we encode are _not_ subsampled (we explicitly enforce the sample count of a `4:4:4` layout) the tag _must_ be present and specify this. Here's two images that show the difference:

[ycbcr-correct.tiff](https://github.com/user-attachments/files/24440084/ycbcr-correct.tiff)
[ycbcr-wrong.tiff](https://github.com/user-attachments/files/24440085/ycbcr-wrong.tiff)

Note that the intended data is a full `256×256` grid going from R,G=0 to R,G=255 in X and Y orientation respectively with blue being the middle point between the other colors. That is, the top-left corner must be full black and the bottom-right must be full white. For the second image the samples are interpreted incorrectly and we get a mash. The first image is the state after this PR.