### PR TITLE
Remove benchmark images from distribution

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ authors = ["The image-rs Developers"]
 repository = "https://github.com/image-rs/image-tiff"
 categories = ["multimedia::images", "multimedia::encoding"]
 
-exclude = ["tests/images/*", "tests/fuzz_images/*"]
+exclude = ["tests/images/*", "tests/fuzz_images/*", "tests/**/*.tif"]
 
 [dependencies]
 half = { version = "2.4.1" }


### PR DESCRIPTION
While packaging for publish I noticed ~1.4MB crate size which is odd. Turns out, we excluded images in `tests` based on very specific paths and the benchmark artifacts (tests/benches) were *not* excluded. This seems to have been an issue [for a long time](https://docs.rs/crate/tiff/0.6.0/source/tests/benches/). I'm sorry for the consumed `crates.io` bandwidth (several TB _per month_).