### PR TITLE
Helper method to copy EXIF data

### DIFF
--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -2,27 +2,27 @@ pub use tiff_value::*;
 
 use std::{
     cmp,
-    io::{self, Seek, Write},
+    io::{self, Read, Seek, Write},
     marker::PhantomData,
     mem,
     num::{NonZeroU64, TryFromIntError},
 };
 
 use crate::{
-    decoder::{ifd::Entry, IfdDecoder},
+    decoder::{ifd::Entry, Decoder},
     error::{TiffResult, UsageError},
     tags::{
         ByteOrder, CompressionMethod, ExtraSamples, IfdPointer, PhotometricInterpretation,
-        ResolutionUnit, SampleFormat, Tag, Type, ValueBuffer,
+        PlanarConfiguration, ResolutionUnit, SampleFormat, Tag, Type, ValueBuffer,
     },
     Directory, TiffError, TiffFormatError,
 };
 
 pub mod colortype;
 pub mod compression;
+mod tag_filter;
 mod tiff_value;
 mod writer;
-mod tag_filter;
 
 use self::colortype::*;
 use self::compression::Compression as Comp;
@@ -438,16 +438,142 @@ impl<'a, W: 'a + Write + Seek, K: TiffKind> DirectoryEncoder<'a, W, K> {
     }
 
     /// Copy metadata from the IFD that a decoder refers to.
-    pub fn write_metadata_from(
+    ///
+    /// You generally want to use [`ImageEncoder::write_metadata_copy_from`] which automatically
+    /// fills out the [`EncodeMetadataApplicability`] as applicable to the chosen color space and
+    /// other sample configuration.
+    pub fn write_metadata_copy_from<R: Read + Seek>(
         &mut self,
-        mut decoder: IfdDecoder<'_>,
+        decoder: &mut Decoder<R>,
         options: EncodeMetadataOptions<'_>,
+        kind: EncodeMetadataApplicability,
     ) -> TiffResult<EncodeMetadataReport> {
         let mut report = EncodeMetadataReport {
+            copied: 0,
+            filtered: 0,
         };
 
-        for tag in decoder.tag_iter() {
-            let (tag, entry) = tag?;
+        enum Role {
+            Ifd,
+            ExifPrivate,
+            GpsPrivate,
+        }
+
+        let ptr = decoder.ifd_pointer().unwrap();
+        let mut stack = vec![(ptr, Role::Ifd, usize::MAX)];
+        let mut buf = ValueBuffer::empty(Type::UNDEFINED);
+
+        // Directories which we will later write in reverse-pre-order.
+        let mut pre_order_dirs: Vec<(Directory, usize, Tag)> = vec![];
+
+        while let Some((ifd, role, parent)) = stack.pop() {
+            let dir = decoder.read_directory(ifd)?;
+            let mut created_dir = Directory::empty();
+
+            let filter = match role {
+                Role::Ifd => TagFilter::filter_primary,
+                Role::ExifPrivate => TagFilter::filter_exif_private,
+                Role::GpsPrivate => TagFilter::filter_gps_private,
+            };
+
+            let mut ifd_reader = decoder.read_directory_tags(&dir);
+
+            for (tag, entry) in dir.iter() {
+                let level = filter(options.tag_filter, tag.to_u16());
+                match options
+                    .tag_filter
+                    .should_keep_for_image_writer(level, &kind)
+                {
+                    tag_filter::Choice::Ok => {}
+                    tag_filter::Choice::Descend(subifd_kind) => {
+                        // Only single pointers can be directories to descend to, avoid an overly
+                        // large read by pulling that value out of the file.
+                        if entry.count() != 1 {
+                            report.filtered = report.filtered.saturating_add(1);
+                            continue;
+                        }
+
+                        if ifd_reader.find_tag_buf(tag, &mut buf)?.is_none() {
+                            // Should not happen (we're iterating the dict already), but be robust.
+                            report.filtered = report.filtered.saturating_add(1);
+                            continue;
+                        };
+
+                        let Some(ifd) = buf.as_ifd_pointer() else {
+                            report.filtered = report.filtered.saturating_add(1);
+                            continue;
+                        };
+
+                        let role = match subifd_kind {
+                            tag_filter::SubifdKind::ExifPrivate => Role::ExifPrivate,
+                            tag_filter::SubifdKind::Gps => Role::GpsPrivate,
+                            tag_filter::SubifdKind::Interoperability => {
+                                // Only applicable to compressed images.
+                                report.filtered = report.filtered.saturating_add(1);
+                                continue;
+                            }
+                        };
+
+                        let this_as_parent = pre_order_dirs.len();
+                        stack.push((ifd, role, this_as_parent));
+                    }
+                    tag_filter::Choice::Discard => continue,
+                    tag_filter::Choice::Filtered
+                    // Not supported yet.
+                    | tag_filter::Choice::Special(tag_filter::Special::JpegThumbnail) => {
+                        // Not to be copied.
+                        report.filtered = report.filtered.saturating_add(1);
+                        continue;
+                    }
+                    tag_filter::Choice::Special(tag_filter::Special::CompressedExclusive) => {
+                        // We're not writing an App segment for a compressed file, are we?
+                        continue;
+                    }
+                }
+
+                if ifd_reader.find_tag_buf(tag, &mut buf)?.is_none() {
+                    report.filtered = report.filtered.saturating_add(1);
+                    continue;
+                }
+
+                // Re-encode the value to the target file.
+                buf.set_byte_order(ByteOrder::native());
+                let entry = self.write_entry_buf(&buf)?;
+                created_dir.extend([(tag, entry)]);
+                report.copied = report.copied.saturating_add(1);
+            }
+
+            let tag_in_parent = match role {
+                // should be unreachable? For now. But thumbnails would use this so we best be a
+                // little cautious here. Also thumbnails are weird, they do have image data but we
+                // would not copy that data itself with these methods. Just eh.
+                //
+                // Anyways the tree root will use this tag as a dummy.
+                Role::Ifd => Tag::SubIfd,
+                Role::ExifPrivate => Tag::ExifDirectory,
+                Role::GpsPrivate => Tag::GpsDirectory,
+            };
+
+            pre_order_dirs.push((created_dir, parent, tag_in_parent));
+        }
+
+        // Now post-order traverse the directory tree.
+        while let Some((directory, parent, tag)) = pre_order_dirs.pop() {
+            // The root is the items for the IFD itself.
+            if pre_order_dirs.is_empty() {
+                // We do not enter ourselves into a parent directory.
+                let _ = (parent, tag);
+
+                self.extend_from(&directory);
+                break;
+            }
+
+            let offset = Self::write_directory_inner(self.writer, &directory)?;
+            let offset = K::convert_offset(offset)?;
+            let entry = self.write_entry(offset)?;
+
+            let (parent_dir, _, _) = &mut pre_order_dirs[parent];
+            parent_dir.extend([(tag, entry)]);
         }
 
         Ok(report)
@@ -479,17 +605,21 @@ impl<'a, W: 'a + Write + Seek, K: TiffKind> DirectoryEncoder<'a, W, K> {
     }
 
     fn write_directory(&mut self) -> TiffResult<u64> {
+        Self::write_directory_inner(self.writer, &self.directory)
+    }
+
+    fn write_directory_inner(writer: &mut TiffWriter<W>, directory: &Directory) -> TiffResult<u64> {
         // Start by turning all buffered unwritten values into entries.
-        let offset = self.writer.offset();
-        K::write_entry_count(self.writer, self.directory.len())?;
+        let offset = writer.offset();
+        K::write_entry_count(writer, directory.len())?;
 
         let offset_bytes = mem::size_of::<K::OffsetType>();
-        for (tag, entry) in self.directory.iter() {
-            self.writer.write_u16(tag.to_u16())?;
-            self.writer.write_u16(entry.field_type().to_u16())?;
+        for (tag, entry) in directory.iter() {
+            writer.write_u16(tag.to_u16())?;
+            writer.write_u16(entry.field_type().to_u16())?;
             let count = K::convert_offset(entry.count())?;
-            count.write(self.writer)?;
-            self.writer.write_bytes(&entry.offset()[..offset_bytes])?;
+            count.write(writer)?;
+            writer.write_bytes(&entry.offset()[..offset_bytes])?;
         }
 
         Ok(offset)
@@ -617,16 +747,46 @@ pub struct EncodeMetadataOptions<'lt> {
     /// Setting this flag will skip such unknown tags instead of attempting a potentially incorrect
     /// copy. However the set of copied metadata is then dependent on the `tiff` library.
     pub tag_filter: &'lt TagFilter,
-    /// Some tags are not allowed to be recorded or can be semantically validated. The library can
-    /// skip these tags while copying metadata. For instance, `YCbCrCoefficients` _may_ be
-    /// recorded for images in `YCbCr` photometric interpretation but _must not_ be recorded for
-    /// images in any other interpretation (colorspace conversion should have been done during the
-    /// transformation).
-    pub skip_invalid_tags: bool,
+    // TODO:
+    // Some tags are not allowed to be recorded or can be semantically validated. The library can
+    // skip these tags while copying metadata. For instance, `YCbCrCoefficients` _may_ be
+    // recorded for images in `YCbCr` photometric interpretation but _must not_ be recorded for
+    // images in any other interpretation (colorspace conversion should have been done during the
+    // transformation).
+    // pub validate_tags: enum ValidateTags {
+    //   None,
+    //   Skip,
+    //   Error,
+    //   Strict /* Error but also do not allow anything that can not be validated */
+    // },
+}
+
+impl Default for EncodeMetadataOptions<'_> {
+    fn default() -> Self {
+        EncodeMetadataOptions {
+            tag_filter: TagFilter::only_known_tags(),
+        }
+    }
+}
+
+/// Describe the kind of image for which metadata is recorded.
+///
+/// Metadata that is not applicable to the color space or the layout may be skipped. For instance,
+/// subsampling basis position is only relevant on YCbCr / Chroma color photometric interpretation
+/// where subsampling is defined.
+#[non_exhaustive]
+#[derive(Clone, Copy, Default)]
+pub struct EncodeMetadataApplicability {
+    pub photometric: Option<PhotometricInterpretation>,
+    pub planar: Option<PlanarConfiguration>,
 }
 
 #[non_exhaustive]
 pub struct EncodeMetadataReport {
+    /// Number of tags transferred (recursively).
+    pub copied: u64,
+    /// Number of tags encountered that were skipped due to the provided filter.
+    pub filtered: u64,
 }
 
 /// Type to encode images strip by strip.
@@ -867,6 +1027,22 @@ impl<'a, W: 'a + Write + Seek, T: ColorType, K: TiffKind> ImageEncoder<'a, W, T,
         self.encoder.writer.reset_compression();
         self.finish()?;
         Ok(())
+    }
+
+    /// Copy metadata from the IFD that a decoder refers to.
+    pub fn write_metadata_copy_from<R: Read + Seek>(
+        &mut self,
+        decoder: &mut Decoder<R>,
+        options: EncodeMetadataOptions<'_>,
+    ) -> TiffResult<EncodeMetadataReport> {
+        self.encoder.write_metadata_copy_from(
+            decoder,
+            options,
+            EncodeMetadataApplicability {
+                photometric: Some(<T>::TIFF_VALUE),
+                planar: Some(PlanarConfiguration::Chunky),
+            },
+        )
     }
 
     /// Set image resolution

--- a/src/encoder/mod.rs
+++ b/src/encoder/mod.rs
@@ -777,7 +777,15 @@ impl Default for EncodeMetadataOptions<'_> {
 #[non_exhaustive]
 #[derive(Clone, Copy, Default)]
 pub struct EncodeMetadataApplicability {
+    /// The photometric interpretation of the image data.
+    ///
+    /// If `None` then metadata tags are not filtered, otherwise only tags applicable to the given
+    /// photometric interpretation are recorded.
     pub photometric: Option<PhotometricInterpretation>,
+    /// The planar configuration of the image data.
+    ///
+    /// If `None` then metadata tags are not filtered, otherwise only tags applicable to the given
+    /// configuration are recorded.
     pub planar: Option<PlanarConfiguration>,
 }
 

--- a/src/encoder/tag_filter.rs
+++ b/src/encoder/tag_filter.rs
@@ -169,16 +169,10 @@ impl TagFilter {
             Level::Photometric(photometric) => {
                 match (photometric, target.planar, target.photometric) {
                     (Photometric::All, _, _) => Choice::Ok,
-                    (Photometric::Planar, Some(PlanarConfiguration::Planar), _) => Choice::Ok,
-                    (Photometric::Planar, None, _)
-                        if matches!(self.filter_level, FilterLevel::All) =>
-                    {
+                    (Photometric::Planar, Some(PlanarConfiguration::Planar) | None, _) => {
                         Choice::Ok
                     }
-                    (Photometric::YCbCr, _, Some(PhotometricInterpretation::YCbCr)) => Choice::Ok,
-                    (Photometric::YCbCr, _, None)
-                        if matches!(self.filter_level, FilterLevel::All) =>
-                    {
+                    (Photometric::YCbCr, _, Some(PhotometricInterpretation::YCbCr) | None) => {
                         Choice::Ok
                     }
                     _ => Choice::Discard,

--- a/src/encoder/tag_filter.rs
+++ b/src/encoder/tag_filter.rs
@@ -1,0 +1,171 @@
+/// A filter of tags copied in
+/// [`DirectoryEncoder::write_metadata_from`][`super::DirectoryEncoder::write_metadata_from`].
+pub struct TagFilter {
+    unknown: bool,
+}
+
+impl TagFilter {
+    /// Return a filter that allows all tags from metadata subdirectories.
+    pub fn allow_all_in_subdirectories() -> &'static TagFilter {
+        static INSTANCE: TagFilter = TagFilter { unknown: true };
+        &INSTANCE
+    }
+
+    /// Return a filter that has an explicit allow list of tags, for each of a known list of
+    /// metadata subdirectories.
+    pub fn allow_known() -> &'static TagFilter {
+        static INSTANCE: TagFilter = TagFilter { unknown: false };
+        &INSTANCE
+    }
+
+    /// As per EXIF V3.0 tags, Primary Image (0th IFD).
+    pub(crate) fn filter_primary_exif(&self, tag: u16) -> Level {
+        match tag {
+            // width, height, etc
+            0x0100..=0x0103 => Level::SampleLayout,
+            // photometric interpretation
+            0x0106 => Level::SampleLayout,
+            0x010e..=0x0110 => Level::Basic,
+            // strip offsets
+            0x0111 => Level::SampleLayout,
+            0x0112 => Level::Basic,
+            // strip byte counts, samples
+            0x0115..=0x0117 => Level::SampleLayout,
+            0x011a..=0x011b => Level::Basic,
+            // planar configuration
+            0x011c => Level::Photometric(Photometric::Planar),
+            0x0128 => Level::Basic,
+            // transfer function
+            0x012d => Level::Photometric(Photometric::All),
+            0x0131..=0x0132 => Level::Basic,
+            0x013b => Level::Basic,
+            // Whitepoint, Chromaticities
+            0x013e..=0x013f => Level::Photometric(Photometric::All),
+            // The table lists these as Not allowed for anything but we may have a choice here for
+            // older models of images.
+            0x0201..=0x0202 => Level::Special(Special::JpegThumbnail),
+            0x0211..=0x0213 => Level::Photometric(Photometric::YCbCr),
+            0x0214 => Level::Photometric(Photometric::All),
+            0x8298 => Level::Basic,
+            0x8769 => Level::Ifd(SubifdKind::ExifPrivate),
+            _ => Level::Unknown,
+        }
+    }
+
+    pub(crate) fn filter_primary_gps(&self, tag: u16) -> Level {
+        match tag {
+            0x8825 => Level::Ifd(SubifdKind::Gps),
+            _ => Level::Unknown,
+        }
+    }
+
+    pub(crate) fn filter_icc(&self, tag: u16) -> Level {
+        match tag {
+            0x8ff3 => Level::Basic,
+            _ => Level::Unknown,
+        }
+    }
+
+    pub(crate) fn filter_exif_private(&self, tag: u16) -> Level {
+        match tag {
+            0x829a => Level::Basic,
+            0x829d => Level::Basic,
+            0x8822 => Level::Basic,
+            0x8824 => Level::Basic,
+            0x8827 => Level::Basic,
+            0x8828 => Level::Basic,
+            0x8830..=0x8835 => Level::Basic,
+            0x9000 => Level::Basic,
+            0x9003..=0x9004 => Level::Basic,
+            0x9010..=0x9012 => Level::Basic,
+            // Not allowed for uncompressed data!
+            0x9101..=0x9102 => Level::Special(Special::CompressedExclusive),
+            0x9201..=0x9209 => Level::Basic,
+            0x920a => Level::Basic,
+            0x9214 => Level::Basic,
+            0x927c => Level::Basic,
+            0x9286 => Level::Basic,
+            0x9290..=0x9292 => Level::Basic,
+            0x9400..=0x9405 => Level::Basic,
+            0xa000 => Level::Basic,
+            0xa001 => Level::Photometric(Photometric::All),
+            0xa002..=0xa003 => Level::Special(Special::CompressedExclusive),
+            0xa004 => Level::Basic,
+            0xa005 => Level::Ifd(SubifdKind::Interoperability),
+            0xa20b..=0xa20c => Level::Basic,
+            0xa20e..=0xa210 => Level::Basic,
+            0xa214..=0xa215 => Level::Basic,
+            0xa217 => Level::Basic,
+            0xa300..=0xa302 => Level::Basic,
+            0xa401..=0xa40c => Level::Basic,
+            0xa420 => Level::Basic,
+            0xa430..=0xa43c => Level::Basic,
+            0xa460..=0xa462 => Level::Basic,
+            0xa500 => Level::Photometric(Photometric::All),
+            _ => Level::Unknown,
+        }
+    }
+
+    fn filter_gps_private(&self, tag: u16) -> Level {
+        match tag {
+            0x0000..=0x001f => Level::Basic,
+            _ => Level::Unknown,
+        }
+    }
+
+    fn filter_interoperability(&self, tag: u16) -> Level {
+        match tag {
+            0x0001 => Level::Special(Special::CompressedExclusive),
+            _ => Level::Unknown,
+        }
+    }
+
+    pub(crate) fn filter_secondary_exif(&self, tag: u16) -> Level {
+        // No difference for now. The only tabular difference I could spot is the treatment of
+        // sample positioning which is mandatory in the primary IFD of YCbCr but optional for all
+        // following IFDs..
+        self.filter_primary_exif(tag)
+    }
+
+    pub(crate) fn filter_secondary_gps(&self, tag: u16) -> Level {
+        self.filter_primary_gps(tag)
+    }
+}
+
+/// The level of support for a value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Level {
+    Unknown,
+    /// Value describes the image data layout, which we will not want to write into the encoder's
+    /// directory where the image data is written later.
+    SampleLayout,
+    /// Value is an IFD and must be copied by making a subdirectory.
+    Ifd(SubifdKind),
+    Photometric(Photometric),
+    Basic,
+    /// We recognize the tag but it can not be copied by itself through normal means.
+    Special(Special),
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Photometric {
+    All,
+    /// Do not copy for non-planar data.
+    Planar,
+    /// Do not copy for non-YCbCr data.
+    YCbCr,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SubifdKind {
+    ExifPrivate,
+    Gps,
+    Interoperability,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Special {
+    JpegThumbnail,
+    /// May only occur in compressed (JPEG APP segments) data.
+    CompressedExclusive,
+}

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -1,0 +1,37 @@
+use tiff::{
+    decoder::Decoder,
+    encoder::{colortype::Gray8, EncodeMetadataOptions, TiffEncoder},
+    tags::Tag,
+};
+
+#[test]
+fn copies_exif_data() {
+    let src = std::path::PathBuf::from(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/images/predictor-3-gray-f32.tif"
+    ));
+
+    let src = std::fs::File::open(src).unwrap();
+    let mut src = Decoder::new(src).unwrap();
+
+    let mut data = std::io::Cursor::new(vec![]);
+    {
+        let mut dst = TiffEncoder::new(&mut data).unwrap();
+        let mut img = dst.new_image::<Gray8>(1, 1).unwrap();
+
+        let report = img
+            .write_metadata_copy_from(&mut src, EncodeMetadataOptions::default())
+            .unwrap();
+
+        assert_eq!(report.copied, 8);
+        assert_eq!(report.filtered, 0, "There are no tags we do not recognize");
+        img.write_data(&[0x80]).unwrap();
+    }
+
+    data.set_position(0);
+
+    {
+        let mut roundtrip = Decoder::new(data).unwrap();
+        assert!(roundtrip.find_tag(Tag::DateTime).unwrap().is_some());
+    }
+}


### PR DESCRIPTION
The main complexity here is that firstly the entries are a tree and secondly some entries are not-allowed or ill-advised when changing the photometric interpretation / planar configuration of the image data. So we have two use-cases here: 

- copying EXIF data while modifying the image sequence and re-writing the image.
- copying EXIF data into an independent file.

This is solved by classifying tags through a `TagFilter` type. (As an experiment, that could include a 'Personally Identifiable Data' qualification but that is not super well-defined and I'd like to externalize the legal aspect in that through future extension methods, not seeing much adoption for this use without that, too). So there's `All` for copying tags just through their type and count and `Known` to ensure we at least semantically recognize the tags as part of EXIF v3 which enables us to remove tags that would conflict with a changed photometric interpretation / planar configuration.