### PR TITLE
Metadata for 0.11.3 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,14 @@
+# Version 0.11.3
+
+Additions:
+- Added support for `webp` compression (as per GDAL) under the `webp` feature flag (default: off).
+- Added `Decoder::image_ifd`, creating an `IfdDecoder` of the current IFD.
+- Added `IfdDecoder::directory`, returning the `Directory` underlying it.
+- Added `LowerHex` and `UpwerHex` implementations for `IfdPointer`.
+
+Notes:
+- A new example `tiff-ls` demonstrates use of the new features.
+
 # Version 0.11.2
 
 Changes:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tiff"
-version = "0.11.2"
+version = "0.11.3"
 edition = "2021"
 resolver = "2"
 


### PR DESCRIPTION
Snuck a few additions in here that helped me debug SGI Luv but mainly this is for the requested WEBP compression support. My other compression PR missing for full coverage of the libtiffpic test suite is too rough, I don't want to make the release dependent on it.