### PR TITLE
Add safe Rust zstd decoding backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ fax34 = { package = "fax", version = "0.2.6", optional = true }
 flate2 = { version = "1.0.20", optional = true }
 weezl = { version = "0.1.10", optional = true }
 zstd = { version = "0.13", optional = true }
+ruzstd = { version = "0.8.2", optional = true }
 zune-jpeg = { version = "0.5.1", optional = true }
 image-webp = {version = "0.2.4", optional = true }
 
@@ -45,6 +46,9 @@ jpeg = ["dep:zune-jpeg"]
 lzw = ["dep:weezl"]
 webp = ["dep:image-webp"]
 zstd = ["dep:zstd"]
+# Fully safe Rust but much slower Zstd decoding.
+# When both zstd and safe-rust-zstd are enabled, zstd takes precedence.
+safe-rust-zstd = ["dep:ruzstd"]
 
 [[bench]]
 name = "lzw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ lzw = ["dep:weezl"]
 webp = ["dep:image-webp"]
 zstd = ["dep:zstd"]
 # Fully safe Rust but much slower Zstd decoding.
-# When both zstd and safe-rust-zstd are enabled, zstd takes precedence.
-safe-rust-zstd = ["dep:ruzstd"]
+# When both zstd and zstd-safe-rust are enabled, zstd takes precedence.
+zstd-safe-rust = ["dep:ruzstd"]
 
 [[bench]]
 name = "lzw"

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -659,7 +659,7 @@ impl Image {
             )),
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
-            #[cfg(all(not(feature = "zstd"), feature = "safe-rust-zstd"))]
+            #[cfg(all(not(feature = "zstd"), feature = "zstd-safe-rust"))]
             CompressionMethod::ZSTD => Box::new(
                 ruzstd::decoding::StreamingDecoder::new(reader)
                     .map_err(|e| std::io::Error::other(e))?,

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -659,6 +659,8 @@ impl Image {
             )),
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
+            #[cfg(all(not(feature = "zstd"), feature = "safe-rust-zstd"))]
+            CompressionMethod::ZSTD => Box::new(ruzstd::decoding::StreamingDecoder::new(reader).unwrap()), // TODO: Error handling
             CompressionMethod::PackBits => Box::new(PackBitsReader::new(reader, compressed_length)),
             #[cfg(feature = "deflate")]
             CompressionMethod::Deflate | CompressionMethod::OldDeflate => {

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -660,7 +660,10 @@ impl Image {
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
             #[cfg(all(not(feature = "zstd"), feature = "safe-rust-zstd"))]
-            CompressionMethod::ZSTD => Box::new(ruzstd::decoding::StreamingDecoder::new(reader).unwrap()), // TODO: Error handling
+            CompressionMethod::ZSTD => Box::new(
+                ruzstd::decoding::StreamingDecoder::new(reader)
+                    .map_err(|e| std::io::Error::other(e))?,
+            ),
             CompressionMethod::PackBits => Box::new(PackBitsReader::new(reader, compressed_length)),
             #[cfg(feature = "deflate")]
             CompressionMethod::Deflate | CompressionMethod::OldDeflate => {

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -569,7 +569,7 @@ fn test_predictor_3_gray_f32() {
 }
 
 #[test]
-#[cfg(any(feature = "zstd", feature = "safe-rust-zstd"))]
+#[cfg(any(feature = "zstd", feature = "zstd-safe-rust"))]
 fn test_zstd_compression() {
     // gdal_translate -co COMPRESS=ZSTD -co ZSTD_LEVEL=20 int16.tif int16_zstd.tif
     test_image_sum_i16("int16_zstd.tif", ColorType::Gray(16), 354396);

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -569,7 +569,7 @@ fn test_predictor_3_gray_f32() {
 }
 
 #[test]
-#[cfg(feature = "zstd")]
+#[cfg(any(feature = "zstd", feature = "safe-rust-zstd"))]
 fn test_zstd_compression() {
     // gdal_translate -co COMPRESS=ZSTD -co ZSTD_LEVEL=20 int16.tif int16_zstd.tif
     test_image_sum_i16("int16_zstd.tif", ColorType::Gray(16), 354396);


### PR DESCRIPTION
Pros: 100% safe Rust. No memory safety bugs, no C toolchain required

Cons: ~3x slower than libzstd

### Future compatibility notes

The safe Rust impl has no encoding support. That's fine for now since the crate doesn't support encoding Zstd anywyay. When encoding is implemented, we'll have to limit it to the zstd feature only, which should be trivial.

Trifecta Tech Foundation is starting work on a Rust drop-in replacement for libzstd, similar to zlib-rs. When that's ready to use, I expect it to replace the `zstd` feature, and this option to remain available.