### PR TITLE
feat: YCbCr chroma subsampling for non-JPEG compression

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -938,15 +938,10 @@ impl Image {
 
         // Only this color type interprets the tag, which is defined with a default of (2, 2)
         if matches!(color, ColorType::YCbCr(_)) && self.chroma_subsampling != (1, 1) {
-            // The JPEG library does upsampling for us and defines its buffers correctly
-            // (presumably). All other compression schemes are not supported..
-            //
-            // NOTE: as explained in <fa225e820b96bef35f01bf4685654beeb4a8df0c> we may be better
-            // off supporting this tag by consistently upsampling, not by adjusting the buffer
-            // size. At least as a default this makes more sense and is much more permissive in
-            // case the compression stream disagrees with the tags (we would not have enough / or
-            // the wrong buffer layout if we only asked for subsampled planes in a planar layout).
-            if !matches!(self.compression_method, CompressionMethod::ModernJPEG) {
+            // The JPEG library does upsampling for us. For other compression methods,
+            // the expand_chunk pipeline wraps the decompressor in a YCbCrUpsamplingReader
+            // that converts the subsampled block layout to full-resolution pixel rows.
+            if matches!(self.planar_config, PlanarConfiguration::Planar) {
                 return Err(TiffError::UnsupportedError(
                     TiffUnsupportedError::ChromaSubsampling,
                 ));
@@ -1147,7 +1142,7 @@ impl Image {
         let is_all_bits = samples == data_samples;
         let is_output_chunk_rows = layout.row_stride == chunk_row_bytes;
 
-        let mut reader = Self::create_reader(
+        let mut reader: Box<dyn Read> = Self::create_reader(
             reader.inner(),
             compression_method,
             *compressed_bytes,
@@ -1156,6 +1151,20 @@ impl Image {
             self.samples,
             self.fill_order,
         )?;
+
+        // For non-JPEG YCbCr with chroma subsampling, wrap the decompressor in an
+        // upsampling reader that converts the subsampled block layout to full-resolution
+        // pixel rows. JPEG handles upsampling internally.
+        if matches!(color_type, ColorType::YCbCr(_))
+            && self.chroma_subsampling != (1, 1)
+            && !matches!(compression_method, CompressionMethod::ModernJPEG)
+        {
+            reader = Box::new(super::stream::YCbCrUpsamplingReader::new(
+                reader,
+                data_dims,
+                self.chroma_subsampling,
+            ));
+        }
 
         // Extended bit depths (9-15, 17-31): packed N-bit samples must be unpacked to
         // standard-width output samples before endianness fix and predictor.

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -946,6 +946,15 @@ impl Image {
                     TiffUnsupportedError::ChromaSubsampling,
                 ));
             }
+            // Predictor reversal currently runs after upsampling, so the stored
+            // MCU-block layout the predictor was encoded against is already
+            // expanded by the time prediction runs. Reject non-None predictors
+            // until prediction can be applied before the upsampling reader.
+            if self.predictor != Predictor::None {
+                return Err(TiffError::UnsupportedError(
+                    TiffUnsupportedError::ChromaSubsampling,
+                ));
+            }
         }
 
         Ok(ReadoutLayout {

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -948,15 +948,10 @@ impl Image {
 
         // Only this color type interprets the tag, which is defined with a default of (2, 2)
         if matches!(color, ColorType::YCbCr(_)) && self.chroma_subsampling != (1, 1) {
-            // The JPEG library does upsampling for us and defines its buffers correctly
-            // (presumably). All other compression schemes are not supported..
-            //
-            // NOTE: as explained in <fa225e820b96bef35f01bf4685654beeb4a8df0c> we may be better
-            // off supporting this tag by consistently upsampling, not by adjusting the buffer
-            // size. At least as a default this makes more sense and is much more permissive in
-            // case the compression stream disagrees with the tags (we would not have enough / or
-            // the wrong buffer layout if we only asked for subsampled planes in a planar layout).
-            if !matches!(self.compression_method, CompressionMethod::ModernJPEG) {
+            // The JPEG library does upsampling for us. For other compression methods,
+            // the expand_chunk pipeline wraps the decompressor in a YCbCrUpsamplingReader
+            // that converts the subsampled block layout to full-resolution pixel rows.
+            if matches!(self.planar_config, PlanarConfiguration::Planar) {
                 return Err(TiffError::UnsupportedError(
                     TiffUnsupportedError::ChromaSubsampling,
                 ));
@@ -1157,7 +1152,7 @@ impl Image {
         let is_all_bits = samples == data_samples;
         let is_output_chunk_rows = layout.row_stride == chunk_row_bytes;
 
-        let mut reader = Self::create_reader(
+        let mut reader: Box<dyn Read> = Self::create_reader(
             reader.inner(),
             compression_method,
             *compressed_bytes,
@@ -1166,6 +1161,20 @@ impl Image {
             self.samples,
             self.fill_order,
         )?;
+
+        // For non-JPEG YCbCr with chroma subsampling, wrap the decompressor in an
+        // upsampling reader that converts the subsampled block layout to full-resolution
+        // pixel rows. JPEG handles upsampling internally.
+        if matches!(color_type, ColorType::YCbCr(_))
+            && self.chroma_subsampling != (1, 1)
+            && !matches!(compression_method, CompressionMethod::ModernJPEG)
+        {
+            reader = Box::new(super::stream::YCbCrUpsamplingReader::new(
+                reader,
+                data_dims,
+                self.chroma_subsampling,
+            ));
+        }
 
         // Extended bit depths (9-15, 17-31): packed N-bit samples must be unpacked to
         // standard-width output samples before endianness fix and predictor.

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -956,6 +956,15 @@ impl Image {
                     TiffUnsupportedError::ChromaSubsampling,
                 ));
             }
+            // Predictor reversal currently runs after upsampling, so the stored
+            // MCU-block layout the predictor was encoded against is already
+            // expanded by the time prediction runs. Reject non-None predictors
+            // until prediction can be applied before the upsampling reader.
+            if self.predictor != Predictor::None {
+                return Err(TiffError::UnsupportedError(
+                    TiffUnsupportedError::ChromaSubsampling,
+                ));
+            }
         }
 
         Ok(ReadoutLayout {

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -510,6 +510,90 @@ impl Read for Group3Reader {
     }
 }
 
+/// Converts YCbCr data from chroma-subsampled block layout to full-resolution
+/// 3-bytes-per-pixel YCbCr output. Each block of h×v pixels stores h*v Y samples
+/// plus one shared Cb and one shared Cr sample. This reader expands those into
+/// per-pixel (Y, Cb, Cr) triples.
+pub struct YCbCrUpsamplingReader<R: Read> {
+    reader: R,
+    width: u32,
+    horiz_sub: u32,
+    vert_sub: u32,
+    height: u32,
+    current_row: u32,
+    output_buf: io::Cursor<Vec<u8>>,
+}
+
+impl<R: Read> YCbCrUpsamplingReader<R> {
+    pub fn new(reader: R, dimensions: (u32, u32), chroma: (u16, u16)) -> Self {
+        Self {
+            reader,
+            width: dimensions.0,
+            horiz_sub: u32::from(chroma.0),
+            vert_sub: u32::from(chroma.1),
+            height: dimensions.1,
+            current_row: 0,
+            output_buf: io::Cursor::new(Vec::new()),
+        }
+    }
+}
+
+impl<R: Read> Read for YCbCrUpsamplingReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        // If output buffer is exhausted, decode next block row
+        if self.output_buf.position() as usize >= self.output_buf.get_ref().len() {
+            if self.current_row >= self.height {
+                return Ok(0);
+            }
+
+            let h = self.horiz_sub;
+            let v = self.vert_sub;
+            let blocks_across = self.width.div_ceil(h);
+            let block_size = (h * v + 2) as usize;
+            let block_row_bytes = blocks_across as usize * block_size;
+
+            let rows_in_block = v.min(self.height - self.current_row) as usize;
+
+            let mut subsampled = vec![0u8; block_row_bytes];
+            self.reader.read_exact(&mut subsampled)?;
+
+            let output_row_bytes = self.width as usize * 3;
+            let output = self.output_buf.get_mut();
+            output.clear();
+            output.resize(rows_in_block * output_row_bytes, 0);
+
+            let mut src_offset = 0;
+            for bx in 0..blocks_across {
+                let x0 = (bx * h) as usize;
+
+                let y_samples = &subsampled[src_offset..src_offset + (h * v) as usize];
+                let cb = subsampled[src_offset + (h * v) as usize];
+                let cr = subsampled[src_offset + (h * v) as usize + 1];
+                src_offset += block_size;
+
+                for dy in 0..rows_in_block {
+                    for dx in 0..h as usize {
+                        let x = x0 + dx;
+                        if x >= self.width as usize {
+                            break;
+                        }
+                        let y_val = y_samples[dy * h as usize + dx];
+                        let pixel_offset = dy * output_row_bytes + x * 3;
+                        output[pixel_offset] = y_val;
+                        output[pixel_offset + 1] = cb;
+                        output[pixel_offset + 2] = cr;
+                    }
+                }
+            }
+
+            self.current_row += v;
+            self.output_buf.set_position(0);
+        }
+
+        self.output_buf.read(buf)
+    }
+}
+
 #[cfg(feature = "webp")]
 pub struct WebPReader {
     inner: Cursor<Vec<u8>>,

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -673,4 +673,113 @@ mod test {
         ];
         assert_eq!(decoded, expected);
     }
+
+    fn mcu_block(y: &[u8], cb: u8, cr: u8) -> Vec<u8> {
+        let mut v = y.to_vec();
+        v.push(cb);
+        v.push(cr);
+        v
+    }
+
+    fn upsample(input: Vec<u8>, dims: (u32, u32), chroma: (u16, u16)) -> Vec<u8> {
+        let mut reader = YCbCrUpsamplingReader::new(io::Cursor::new(input), dims, chroma);
+        let mut out = Vec::new();
+        reader.read_to_end(&mut out).unwrap();
+        out
+    }
+
+    #[test]
+    fn ycbcr_upsample_2x2() {
+        let mut input = Vec::new();
+        input.extend(mcu_block(&[10, 11, 12, 13], 100, 200));
+        input.extend(mcu_block(&[20, 21, 22, 23], 110, 210));
+        input.extend(mcu_block(&[30, 31, 32, 33], 120, 220));
+        input.extend(mcu_block(&[40, 41, 42, 43], 130, 230));
+
+        #[rustfmt::skip]
+        let expected: Vec<u8> = vec![
+            10,100,200, 11,100,200, 20,110,210, 21,110,210,
+            12,100,200, 13,100,200, 22,110,210, 23,110,210,
+            30,120,220, 31,120,220, 40,130,230, 41,130,230,
+            32,120,220, 33,120,220, 42,130,230, 43,130,230,
+        ];
+        assert_eq!(upsample(input, (4, 4), (2, 2)), expected);
+    }
+
+    #[test]
+    fn ycbcr_upsample_2x1_horizontal_only() {
+        let mut input = Vec::new();
+        input.extend(mcu_block(&[10, 11], 100, 200));
+        input.extend(mcu_block(&[20, 21], 110, 210));
+        input.extend(mcu_block(&[30, 31], 120, 220));
+        input.extend(mcu_block(&[40, 41], 130, 230));
+
+        #[rustfmt::skip]
+        let expected: Vec<u8> = vec![
+            10,100,200, 11,100,200, 20,110,210, 21,110,210,
+            30,120,220, 31,120,220, 40,130,230, 41,130,230,
+        ];
+        assert_eq!(upsample(input, (4, 2), (2, 1)), expected);
+    }
+
+    #[test]
+    fn ycbcr_upsample_1x2_vertical_only() {
+        let mut input = Vec::new();
+        input.extend(mcu_block(&[10, 11], 100, 200));
+        input.extend(mcu_block(&[20, 21], 110, 210));
+        input.extend(mcu_block(&[30, 31], 120, 220));
+        input.extend(mcu_block(&[40, 41], 130, 230));
+
+        #[rustfmt::skip]
+        let expected: Vec<u8> = vec![
+            10,100,200, 20,110,210,
+            11,100,200, 21,110,210,
+            30,120,220, 40,130,230,
+            31,120,220, 41,130,230,
+        ];
+        assert_eq!(upsample(input, (2, 4), (1, 2)), expected);
+    }
+
+    #[test]
+    fn ycbcr_upsample_4x4() {
+        let y: Vec<u8> = (0u8..16).collect();
+        let input = mcu_block(&y, 128, 64);
+
+        let mut expected = Vec::with_capacity(48);
+        for yi in &y {
+            expected.push(*yi);
+            expected.push(128);
+            expected.push(64);
+        }
+        assert_eq!(upsample(input, (4, 4), (4, 4)), expected);
+    }
+
+    #[test]
+    fn ycbcr_upsample_nondivisible_width() {
+        let mut input = Vec::new();
+        input.extend(mcu_block(&[10, 11, 12, 13], 100, 200));
+        input.extend(mcu_block(&[20, 21, 22, 23], 110, 210));
+
+        #[rustfmt::skip]
+        let expected: Vec<u8> = vec![
+            10,100,200, 11,100,200, 20,110,210,
+            12,100,200, 13,100,200, 22,110,210,
+        ];
+        assert_eq!(upsample(input, (3, 2), (2, 2)), expected);
+    }
+
+    #[test]
+    fn ycbcr_upsample_nondivisible_height() {
+        let mut input = Vec::new();
+        input.extend(mcu_block(&[10, 11, 12, 13], 100, 200));
+        input.extend(mcu_block(&[20, 21, 22, 23], 110, 210));
+
+        #[rustfmt::skip]
+        let expected: Vec<u8> = vec![
+            10,100,200, 11,100,200,
+            12,100,200, 13,100,200,
+            20,110,210, 21,110,210,
+        ];
+        assert_eq!(upsample(input, (2, 3), (2, 2)), expected);
+    }
 }

--- a/tests/decode_libtiffpic.rs
+++ b/tests/decode_libtiffpic.rs
@@ -173,7 +173,7 @@ const FILES: &[(&str, Option<u32>)] = &[
     ("tests/libtiffpic/depth/genimages", None),
     ("tests/libtiffpic/depth/README.txt", None),
     ("tests/libtiffpic/depth/summary.txt", None),
-    ("tests/libtiffpic/dscf0013.tif", Some(0)), // unsupported YCbCr chroma subsampling
+    ("tests/libtiffpic/dscf0013.tif", Some(0x6896e83a)),
     ("tests/libtiffpic/fax2d.tif", Some(0xc2f30c6f)),
     // No support for direct CCITT Group 3 1D format
     ("tests/libtiffpic/g3test.g3", None),
@@ -193,11 +193,11 @@ const FILES: &[(&str, Option<u32>)] = &[
     ("tests/libtiffpic/quad-lzw.tif", Some(0)), // invalid LZW stream
     ("tests/libtiffpic/quad-tile.tif", Some(0x6055f9ee)),
     ("tests/libtiffpic/README", None),
-    ("tests/libtiffpic/smallliz.tif", Some(0)), // unsupported YCbCr chroma subsampling
+    ("tests/libtiffpic/smallliz.tif", Some(0)), // unsupported Old JPEG compression (type 6)
     ("tests/libtiffpic/strike.tif", Some(0x016b0f6a)),
     ("tests/libtiffpic/text.tif", Some(0)), // unsupported compression
-    ("tests/libtiffpic/ycbcr-cat.tif", Some(0)), // unsupported YCbCr chroma subsampling
-    ("tests/libtiffpic/zackthecat.tif", Some(0)), // unsupported YCbCr chroma subsampling
+    ("tests/libtiffpic/ycbcr-cat.tif", Some(0x388a9d8f)),
+    ("tests/libtiffpic/zackthecat.tif", Some(0)), // unsupported Old JPEG compression (type 6)
 ];
 
 fn main() {


### PR DESCRIPTION
Follow-up to #387. Brings back 83409cb (reverted in 85215e8) with two extra patches to address gaps.

First commit is a clean cherry-pick of 83409cb — `YCbCrUpsamplingReader` that converts MCU-block layout into full-res YCbCr triples, wired into expand_chunk for non-JPEG YCbCr. Libtiffpic hashes updated for `tests/libtiffpic/dscf0013.tif` (uncompressed 4:2:2) and `tests/libtiffpic/ycbcr-cat.tif` (LZW 4:2:0).

Second commit does two things:

- Rejects predictor != None with subsampling. The pipeline currently reverses the predictor after upsampling, but the predictor was encoded against the stored block layout — reversing it on upsampled data is wrong. Latent bug in the original that isn't exercised because both libtiffpic test files use predictor=1. Erroring out keeps the scope tight; reordering prediction to run before upsampling can be a follow-up.
- Adds unit tests for YCbCrUpsamplingReader in isolation: (2,2), (2,1), (1,2), (4,4), plus non-divisible width/height where the final block column/row gets clipped.

Planar YCbCr + subsampling stays rejected as in the cherry-pick.

cargo test, cargo clippy --all-targets, cargo test --test decode_libtiffpic all green (61/61).