### PR TITLE
fix: correct interpretation of extra samples with unspecified type of alpha

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -1190,7 +1190,7 @@ impl Image {
                 super::fix_endianness_and_predict(
                     out_row,
                     color_type.bit_depth(),
-                    samples,
+                    data_samples,
                     ByteOrder::native(),
                     predictor,
                     scratch,

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -518,7 +518,7 @@ impl Image {
         let is_alpha_extra_samples = matches!(
             self.extra_samples.as_slice(),
             [ExtraSamples::AssociatedAlpha, ..] | [ExtraSamples::UnassociatedAlpha, ..]
-        );
+        ) || self.samples > self.photometric_samples;
 
         match self.photometric_interpretation {
             PhotometricInterpretation::RGB => match self.photometric_samples {

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -975,7 +975,7 @@ fn extra_bits_gray() {
 
 #[test]
 fn extra_bits_rgb() {
-    test_image_sum_u8("extra_bits_rgb_8b.tiff", ColorType::RGB(8), 0);
+    test_image_sum_u8("extra_bits_rgb_8b.tiff", ColorType::RGBA(8), 64);
 }
 
 #[test]


### PR DESCRIPTION
The commit should correct how TIFF images with samples count larger than photometric samples count are interpreted. For example, if a TIFF image claims a RGB photometric interpretation, a `8 8 8 8` bits-per-sample array, and an unspecified extra samples field (i.e. `ExtraSamples = 0`), the current commit should interpret the image as an RGBA image with the extra sample be treated as the alpha channel of the image, whereas currently the crate would interpret it as a RGB image and produce a corrupted pixel map. 

The test `extra_bits_rgb` is fixed together, and it should now align with the logic of `extra_bits_gray` and `write_extra_bits_image`.