### PR TITLE
Add PhotometricInterpretation unknown tag support

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -660,12 +660,14 @@ impl Image {
                 ),
             )),
             PhotometricInterpretation::RGBPalette => Ok(ColorType::Palette(self.bits_per_sample)),
-            PhotometricInterpretation::TransparencyMask => Err(TiffError::UnsupportedError(
-                TiffUnsupportedError::InterpretationWithBits(
-                    self.photometric_interpretation,
-                    vec![self.bits_per_sample; self.samples as usize],
-                ),
-            )),
+            PhotometricInterpretation::TransparencyMask | PhotometricInterpretation::Unknown(_) => {
+                Err(TiffError::UnsupportedError(
+                    TiffUnsupportedError::InterpretationWithBits(
+                        self.photometric_interpretation,
+                        vec![self.bits_per_sample; self.samples as usize],
+                    ),
+                ))
+            }
         }
     }
 

--- a/src/tags.rs
+++ b/src/tags.rs
@@ -295,7 +295,10 @@ pub enum CompressionMethod(u16) unknown(
 }
 
 tags! {
-pub enum PhotometricInterpretation(u16) {
+pub enum PhotometricInterpretation(u16) unknown(
+    /// A private or extension tag
+    unknown
+) {
     WhiteIsZero = 0,
     BlackIsZero = 1,
     RGB = 2,


### PR DESCRIPTION
Provides a mechanism to support private or extension photometric interpretations (such as CFA)