### PR TITLE
Add safe Rust zstd decoding backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ fax34 = { package = "fax", version = "0.2.6", optional = true }
 flate2 = { version = "1.0.20", optional = true }
 weezl = { version = "0.1.10", optional = true }
 zstd = { version = "0.13", optional = true }
+ruzstd = { version = "0.8.2", optional = true }
 zune-jpeg = { version = "0.5.1", optional = true }
 image-webp = {version = "0.2.4", optional = true }
 
@@ -45,6 +46,9 @@ jpeg = ["dep:zune-jpeg"]
 lzw = ["dep:weezl"]
 webp = ["dep:image-webp"]
 zstd = ["dep:zstd"]
+# Fully safe Rust but much slower Zstd decoding.
+# When both zstd and safe-rust-zstd are enabled, zstd takes precedence.
+safe-rust-zstd = ["dep:ruzstd"]
 
 [[bench]]
 name = "lzw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ lzw = ["dep:weezl"]
 webp = ["dep:image-webp"]
 zstd = ["dep:zstd"]
 # Fully safe Rust but much slower Zstd decoding.
-# When both zstd and safe-rust-zstd are enabled, zstd takes precedence.
-safe-rust-zstd = ["dep:ruzstd"]
+# When both zstd and zstd-safe-rust are enabled, zstd takes precedence.
+zstd-safe-rust = ["dep:ruzstd"]
 
 [[bench]]
 name = "lzw"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ fax34 = { package = "fax", version = "0.2.6", optional = true }
 flate2 = { version = "1.0.20", optional = true }
 weezl = { version = "0.1.10", optional = true }
 zstd = { version = "0.13", optional = true }
-zrip-decode = { version = "0.7.0", features = ["paranoid"], optional = true }
+zrip-decode = { version = "0.8.2", features = ["paranoid"], optional = true }
 zune-jpeg = { version = "0.5.1", optional = true }
 image-webp = {version = "0.2.4", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ fax34 = { package = "fax", version = "0.2.6", optional = true }
 flate2 = { version = "1.0.20", optional = true }
 weezl = { version = "0.1.10", optional = true }
 zstd = { version = "0.13", optional = true }
-ruzstd = { version = "0.8.2", optional = true }
+zrip-decode = { version = "0.7.0", features = ["paranoid"], optional = true }
 zune-jpeg = { version = "0.5.1", optional = true }
 image-webp = {version = "0.2.4", optional = true }
 
@@ -46,9 +46,9 @@ jpeg = ["dep:zune-jpeg"]
 lzw = ["dep:weezl"]
 webp = ["dep:image-webp"]
 zstd = ["dep:zstd"]
-# Fully safe Rust but much slower Zstd decoding.
+# Fully safe Rust but somewhat slower Zstd decoding.
 # When both zstd and zstd-safe-rust are enabled, zstd takes precedence.
-zstd-safe-rust = ["dep:ruzstd"]
+zstd-safe-rust = ["dep:zrip-decode"]
 
 [[bench]]
 name = "lzw"

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -659,7 +659,7 @@ impl Image {
             )),
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
-            #[cfg(all(not(feature = "zstd"), feature = "safe-rust-zstd"))]
+            #[cfg(all(not(feature = "zstd"), feature = "zstd-safe-rust"))]
             CompressionMethod::ZSTD => Box::new(
                 ruzstd::decoding::StreamingDecoder::new(reader)
                     .map_err(|e| std::io::Error::other(e))?,

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -659,6 +659,8 @@ impl Image {
             )),
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
+            #[cfg(all(not(feature = "zstd"), feature = "safe-rust-zstd"))]
+            CompressionMethod::ZSTD => Box::new(ruzstd::decoding::StreamingDecoder::new(reader).unwrap()), // TODO: Error handling
             CompressionMethod::PackBits => Box::new(PackBitsReader::new(reader, compressed_length)),
             #[cfg(feature = "deflate")]
             CompressionMethod::Deflate | CompressionMethod::OldDeflate => {

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -660,7 +660,10 @@ impl Image {
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
             #[cfg(all(not(feature = "zstd"), feature = "safe-rust-zstd"))]
-            CompressionMethod::ZSTD => Box::new(ruzstd::decoding::StreamingDecoder::new(reader).unwrap()), // TODO: Error handling
+            CompressionMethod::ZSTD => Box::new(
+                ruzstd::decoding::StreamingDecoder::new(reader)
+                    .map_err(|e| std::io::Error::other(e))?,
+            ),
             CompressionMethod::PackBits => Box::new(PackBitsReader::new(reader, compressed_length)),
             #[cfg(feature = "deflate")]
             CompressionMethod::Deflate | CompressionMethod::OldDeflate => {

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -660,10 +660,7 @@ impl Image {
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
             #[cfg(all(not(feature = "zstd"), feature = "zstd-safe-rust"))]
-            CompressionMethod::ZSTD => Box::new(
-                ruzstd::decoding::StreamingDecoder::new(reader)
-                    .map_err(|e| std::io::Error::other(e))?,
-            ),
+            CompressionMethod::ZSTD => Box::new(zrip_decode::streaming::FrameDecoder::new(reader)),
             CompressionMethod::PackBits => Box::new(PackBitsReader::new(reader, compressed_length)),
             #[cfg(feature = "deflate")]
             CompressionMethod::Deflate | CompressionMethod::OldDeflate => {

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -569,7 +569,7 @@ fn test_predictor_3_gray_f32() {
 }
 
 #[test]
-#[cfg(any(feature = "zstd", feature = "safe-rust-zstd"))]
+#[cfg(any(feature = "zstd", feature = "zstd-safe-rust"))]
 fn test_zstd_compression() {
     // gdal_translate -co COMPRESS=ZSTD -co ZSTD_LEVEL=20 int16.tif int16_zstd.tif
     test_image_sum_i16("int16_zstd.tif", ColorType::Gray(16), 354396);

--- a/tests/decode_images.rs
+++ b/tests/decode_images.rs
@@ -569,7 +569,7 @@ fn test_predictor_3_gray_f32() {
 }
 
 #[test]
-#[cfg(feature = "zstd")]
+#[cfg(any(feature = "zstd", feature = "safe-rust-zstd"))]
 fn test_zstd_compression() {
     // gdal_translate -co COMPRESS=ZSTD -co ZSTD_LEVEL=20 int16.tif int16_zstd.tif
     test_image_sum_i16("int16_zstd.tif", ColorType::Gray(16), 354396);


### PR DESCRIPTION
Use the new `zrip` crate instead of `ruzstd` proposed in  #349. It is over 2x faster and supports multi-frame streams.

The `paranoid` feature is used to disable all `unsafe` code, other than the `fearless_simd` dependency. However I am biased in favor fearless_simd because I worked on it. If you prefer, `fearless_simd` can also be disabled with `default-features=false`, but the amount of `unsafe` in `fearless_simd` is [very low](https://gist.github.com/Shnatsel/61fc294987a1e051ce3835c97dc0fc19) (just safe multiversioning plus a very minimal equivalent of `safe_unaligned_simd`).

The crate is quite young but stands up to fuzzing and roundtrip fuzzing against the C library (i.e. successfully decodes all streams produced by C libzstd under a fuzzer).

The in-tree zstd TIFF decoding test passes with `zstd-safe-rust` feature.

Zstd remains disabled by default. If both `zstd` and `zstd-safe-rust` features are enabled, `zstd` takes precedence.