### PR TITLE
Fix clippy 1.97 useless_borrows_in_formatting lint failing CI

### DIFF
--- a/src/decoder/ifd.rs
+++ b/src/decoder/ifd.rs
@@ -363,7 +363,7 @@ impl ::std::fmt::Debug for Entry {
     fn fmt(&self, fmt: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
         fmt.write_str(&format!(
             "Entry {{ type_: {:?}, count: {:?}, offset: {:?} }}",
-            self.type_, self.count, &self.offset
+            self.type_, self.count, self.offset
         ))
     }
 }


### PR DESCRIPTION
Rust 1.97's newly stabilized `useless_borrows_in_formatting` clippy lint flags the redundant `&self.offset` in `Entry`'s `Debug` impl (`src/decoder/ifd.rs:366`). Since CI runs `cargo clippy -- -D warnings` in every job, this single pre-existing lint currently fails the pipeline for all PRs against `main` (see e.g. the runs on #402).

One-character fix: `[u8; 8]` is `Copy`, so the borrow was never needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)