### PR TITLE
Cache constructed decompression engines

### DIFF
--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -1204,7 +1204,7 @@ impl Image {
             let mut packed = vec![0u8; chunk_row_bytes];
 
             for row in buf.chunks_mut(layout.row_stride).take(data_dims.1 as usize) {
-                reader.read_samples(&mut packed)?;
+                reader.read_exact(&mut packed)?;
 
                 let out_row = &mut row[..data_row_bytes];
                 unpack_bits(&packed, out_row, tiff_bps, samples_per_data_row, out_bps);
@@ -1238,7 +1238,7 @@ impl Image {
         } else if is_output_chunk_rows && is_all_bits {
             // Here we can read directly into the output buffer itself.
             let tile = &mut buf[..chunk_row_bytes * data_dims.1 as usize];
-            reader.read_samples(tile)?;
+            reader.read_exact(tile)?;
 
             for row in tile.chunks_mut(chunk_row_bytes) {
                 super::fix_endianness_and_predict(
@@ -1272,7 +1272,7 @@ impl Image {
             // this case is handled specially when needed.
             let mut encoded = vec![0u8; chunk_row_bytes];
             for row in buf.chunks_mut(layout.row_stride).take(data_dims.1 as usize) {
-                reader.read_samples(&mut encoded)?;
+                reader.read_exact(&mut encoded)?;
 
                 let row = &mut row[..data_row_bytes];
                 match color_type.bit_depth() {
@@ -1313,7 +1313,7 @@ impl Image {
                     let skip = u64::try_from(chunk_row_bytes - data_row_bytes)?;
                     reader.read_padded_samples(&mut row[..used], skip)?;
                 } else {
-                    reader.read_samples(&mut row[..used])?;
+                    reader.read_exact(&mut row[..used])?;
                 }
 
                 super::fix_endianness_and_predict(
@@ -1371,7 +1371,7 @@ impl Image {
                 // width, and writing their horizontal padding would spill into the following
                 // output row (and predict/invert would run past the chunk's own columns).
                 let row = &mut row[..data_row_bytes];
-                reader.read_samples(&mut encoded)?;
+                reader.read_exact(&mut encoded)?;
 
                 Self::compact_photometric_bytes(&mut encoded, row, &photo_range);
 

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -1,5 +1,5 @@
 use super::ifd::Value;
-use super::stream::PackBitsReader;
+use super::stream::{PackBitsReader, ReadSamples};
 use super::tag_reader::TagReader;
 use super::ChunkType;
 use super::{predict_f16, predict_f32, predict_f64, ValueReader};
@@ -11,7 +11,7 @@ use crate::{
     ColorType, Directory, TiffError, TiffFormatError, TiffResult, TiffUnsupportedError, UsageError,
 };
 
-use std::io::{self, Cursor, Read, Seek};
+use std::io::{Cursor, Read, Seek};
 use std::sync::Arc;
 
 #[derive(Debug)]
@@ -698,7 +698,7 @@ impl Image {
         dimensions: (u32, u32),
         samples: u16,
         #[cfg_attr(not(feature = "fax"), allow(unused_variables))] fill_order: u16,
-    ) -> TiffResult<Box<dyn Read + 'r>> {
+    ) -> TiffResult<Box<dyn ReadSamples + 'r>> {
         Ok(match compression_method {
             CompressionMethod::None => Box::new(reader),
             CompressionMethod::SgiLog => match samples {
@@ -1204,7 +1204,7 @@ impl Image {
             let mut packed = vec![0u8; chunk_row_bytes];
 
             for row in buf.chunks_mut(layout.row_stride).take(data_dims.1 as usize) {
-                reader.read_exact(&mut packed)?;
+                reader.read_samples(&mut packed)?;
 
                 let out_row = &mut row[..data_row_bytes];
                 unpack_bits(&packed, out_row, tiff_bps, samples_per_data_row, out_bps);
@@ -1238,7 +1238,7 @@ impl Image {
         } else if is_output_chunk_rows && is_all_bits {
             // Here we can read directly into the output buffer itself.
             let tile = &mut buf[..chunk_row_bytes * data_dims.1 as usize];
-            reader.read_exact(tile)?;
+            reader.read_samples(tile)?;
 
             for row in tile.chunks_mut(chunk_row_bytes) {
                 super::fix_endianness_and_predict(
@@ -1272,7 +1272,7 @@ impl Image {
             // this case is handled specially when needed.
             let mut encoded = vec![0u8; chunk_row_bytes];
             for row in buf.chunks_mut(layout.row_stride).take(data_dims.1 as usize) {
-                reader.read_exact(&mut encoded)?;
+                reader.read_samples(&mut encoded)?;
 
                 let row = &mut row[..data_row_bytes];
                 match color_type.bit_depth() {
@@ -1308,11 +1308,12 @@ impl Image {
                 // Two ways how we get here: we have more bytes in our chunk data than in the image
                 // we are to read. Then we need to skip the rest of the data. Or we have a bigger
                 // row stride than the chunk contains data, then we  need to fill only the front.
-                reader.read_exact(&mut row[..used])?;
-                // Skip horizontal padding
                 if chunk_row_bytes > data_row_bytes {
-                    let len = u64::try_from(chunk_row_bytes - data_row_bytes)?;
-                    io::copy(&mut reader.by_ref().take(len), &mut io::sink())?;
+                    // Skip horizontal padding
+                    let skip = u64::try_from(chunk_row_bytes - data_row_bytes)?;
+                    reader.read_padded_samples(&mut row[..used], skip)?;
+                } else {
+                    reader.read_samples(&mut row[..used])?;
                 }
 
                 super::fix_endianness_and_predict(
@@ -1370,7 +1371,7 @@ impl Image {
                 // width, and writing their horizontal padding would spill into the following
                 // output row (and predict/invert would run past the chunk's own columns).
                 let row = &mut row[..data_row_bytes];
-                reader.read_exact(&mut encoded)?;
+                reader.read_samples(&mut encoded)?;
 
                 Self::compact_photometric_bytes(&mut encoded, row, &photo_range);
 

--- a/src/decoder/image.rs
+++ b/src/decoder/image.rs
@@ -3,6 +3,7 @@ use super::stream::{PackBitsReader, ReadSamples};
 use super::tag_reader::TagReader;
 use super::ChunkType;
 use super::{predict_f16, predict_f32, predict_f64, ValueReader};
+use crate::decoder::stream::CompressionEngines;
 use crate::tags::{
     ByteOrder, CompressionMethod, ExtraSamples, PhotometricInterpretation, PlanarConfiguration,
     Predictor, SampleFormat, Tag,
@@ -698,6 +699,7 @@ impl Image {
         dimensions: (u32, u32),
         samples: u16,
         #[cfg_attr(not(feature = "fax"), allow(unused_variables))] fill_order: u16,
+        engines: &mut CompressionEngines,
     ) -> TiffResult<Box<dyn ReadSamples + 'r>> {
         Ok(match compression_method {
             CompressionMethod::None => Box::new(reader),
@@ -729,6 +731,7 @@ impl Image {
             CompressionMethod::LZW => Box::new(super::stream::LZWReader::new(
                 reader,
                 usize::try_from(compressed_length)?,
+                engines,
             )),
             #[cfg(feature = "zstd")]
             CompressionMethod::ZSTD => Box::new(zstd::Decoder::new(reader)?),
@@ -1033,6 +1036,7 @@ impl Image {
         layout: &ReadoutLayout,
         chunk_index: u32,
         scratch: &mut Vec<u8>,
+        engines: &mut CompressionEngines,
     ) -> TiffResult<()> {
         let ValueReader {
             reader,
@@ -1179,6 +1183,7 @@ impl Image {
             chunk_dims,
             self.samples,
             self.fill_order,
+            engines,
         )?;
 
         // Extended bit depths (9-15, 17-31): packed N-bit samples must be unpacked to
@@ -1403,6 +1408,7 @@ impl Image {
             }
         }
 
+        reader.cache_or_destroy(engines);
         Ok(())
     }
 

--- a/src/decoder/logluv.rs
+++ b/src/decoder/logluv.rs
@@ -83,6 +83,14 @@ impl<R: Read> Read for LogLuv24<R> {
     }
 }
 
+impl<R: Read> super::stream::ReadSamples for LogLuv24<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> std::io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
+    }
+}
+
 fn packbits_decode<R: Read, const N: usize>(
     reader: &mut R,
     buf: &mut [[u8; N]],
@@ -212,6 +220,14 @@ impl<R: Read> Read for LogLuv32<R> {
     }
 }
 
+impl<R: Read> super::stream::ReadSamples for LogLuv32<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> std::io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
+    }
+}
+
 /// Pack-Bits like encoding for a single 16-bit log-L sample.
 pub struct LogLuv16<R> {
     reader: Take<R>,
@@ -274,6 +290,14 @@ impl<R: Read> Read for LogLuv16<R> {
             Self::expand_row(row);
         }
 
+        Ok(())
+    }
+}
+
+impl<R: Read> super::stream::ReadSamples for LogLuv16<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> std::io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
         Ok(())
     }
 }

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -259,6 +259,7 @@ pub struct Decoder<R> {
     scratch: Vec<u8>,
     /// Leniency flag that allows libtiff-like TIFF color interpretation behavior
     lenient: bool,
+    compression: stream::CompressionEngines,
 }
 
 /// All the information needed to read and interpret byte slices from the underlying file, i.e. to
@@ -853,6 +854,7 @@ impl TiffHeader {
             image: None,
             scratch: Vec::new(),
             lenient: false,
+            compression: stream::CompressionEngines::default(),
         }
     }
 }
@@ -949,12 +951,18 @@ impl<R: Read + Seek> Decoder<R> {
     #[expect(clippy::unnecessary_unwrap)] // Lifetimes would overlap due to return.
     fn ensure_image_and_reader(
         &mut self,
-    ) -> TiffResult<(&mut Image, &mut ValueReader<R>, &mut Vec<u8>)> {
+    ) -> TiffResult<(
+        &mut Image,
+        &mut ValueReader<R>,
+        &mut Vec<u8>,
+        &mut stream::CompressionEngines,
+    )> {
         if self.image.is_some() {
             return Ok((
                 self.image.as_mut().unwrap(),
                 &mut self.value_reader,
                 &mut self.scratch,
+                &mut self.compression,
             ));
         }
 
@@ -963,6 +971,7 @@ impl<R: Read + Seek> Decoder<R> {
             self.image.insert(image),
             &mut self.value_reader,
             &mut self.scratch,
+            &mut self.compression,
         ))
     }
 
@@ -1095,6 +1104,7 @@ impl<R: Read + Seek> Decoder<R> {
             image: core::mem::take(&mut self.image),
             scratch: core::mem::take(&mut self.scratch),
             lenient: self.lenient,
+            compression: core::mem::take(&mut self.compression),
         }
     }
 
@@ -1578,10 +1588,10 @@ impl<R: Read + Seek> Decoder<R> {
         chunk_index: u32,
         layout: &image::ReadoutLayout,
     ) -> TiffResult<()> {
-        let (image, value_reader, scratch) = self.ensure_image_and_reader()?;
+        let (image, value_reader, scratch, engines) = self.ensure_image_and_reader()?;
         let offset = image.chunk_file_range(chunk_index)?.0;
         value_reader.reader.goto_offset(offset)?;
-        image.expand_chunk(value_reader, buffer, layout, chunk_index, scratch)?;
+        image.expand_chunk(value_reader, buffer, layout, chunk_index, scratch, engines)?;
         Ok(())
     }
 
@@ -1733,7 +1743,7 @@ impl<R: Read + Seek> Decoder<R> {
         slice: TiffCodingUnit,
         buffer: &mut [u8],
     ) -> TiffResult<()> {
-        let (image, value_reader, scratch) = self.ensure_image_and_reader()?;
+        let (image, value_reader, scratch, engines) = self.ensure_image_and_reader()?;
 
         let (width, height) = image.chunk_data_dimensions(slice.0)?;
         let readout = image.readout_for_size(width, height)?;
@@ -1766,6 +1776,7 @@ impl<R: Read + Seek> Decoder<R> {
                 readout,
                 chunk,
                 scratch,
+                engines,
             )?;
         }
 
@@ -1937,7 +1948,7 @@ impl<R: Read + Seek> Decoder<R> {
     /// Returns an error if the buffer fits less than one plane. In particular, for non-planar
     /// images returns an error if the buffer does not fit the required size.
     pub fn read_image_bytes(&mut self, buffer: &mut [u8]) -> TiffResult<()> {
-        let (image, value_reader, scratch) = self.ensure_image_and_reader()?;
+        let (image, value_reader, scratch, engines) = self.ensure_image_and_reader()?;
         let readout = image.readout_for_image()?;
 
         let ref layout @ image::PlaneLayout {
@@ -1971,6 +1982,7 @@ impl<R: Read + Seek> Decoder<R> {
                     readout,
                     chunk,
                     scratch,
+                    engines,
                 )?;
             }
         }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -122,6 +122,21 @@ impl<R: Read> EndianReader<R> {
 // # READERS
 //
 
+#[derive(Default)]
+pub(crate) struct CompressionEngines {
+    #[cfg(feature = "lzw")]
+    lzw: Option<weezl::decode::Decoder>,
+}
+
+impl core::fmt::Debug for CompressionEngines {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut dbg = f.debug_struct("CompressionEngines");
+        #[cfg(feature = "lzw")]
+        dbg.field("lzw", &self.lzw.is_some().then_some("<weezl>"));
+        dbg.finish()
+    }
+}
+
 /// A variant of `io::Read` that takes one block to the end.
 ///
 /// This is derived from `Read` so that any special optimization done by `std` (or any nightly crate
@@ -142,19 +157,51 @@ pub trait ReadSamples: Read {
     ///
     /// This is automatically implemented for `Self: Read` as a copy into `io::Sink`.
     fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()>;
+
+    /// Put this back into our cache of compression engines.
+    fn cache_or_destroy(self: Box<Self>, _: &mut CompressionEngines) {}
 }
 
-impl<R: Read> ReadSamples for R {
+/// Note: the `Seek` bound ensures this does not overlap actual decompression.. This is an odd
+/// design problem born out of wanting both the underlying `Read` for uncompressed streams due to
+/// performance as well as the override to `cache_or_destroy` for all compressed streams.
+impl<R: Read + Seek> ReadSamples for R {
     fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
         self.read_exact(buf)?;
-        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        if discard > 0 {
+            std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        }
         Ok(())
     }
 }
 
 /// Type alias for the deflate Reader
 #[cfg(feature = "deflate")]
-pub type DeflateReader<R> = flate2::read::ZlibDecoder<R>;
+pub struct DeflateReader<R> {
+    inner: flate2::read::ZlibDecoder<R>,
+}
+
+impl<R: Read> DeflateReader<R> {
+    pub fn new(inner: R) -> Self {
+        DeflateReader {
+            inner: flate2::read::ZlibDecoder::new(inner),
+        }
+    }
+}
+
+impl<R: Read> Read for DeflateReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl<R: Read> ReadSamples for DeflateReader<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
+    }
+}
 
 //
 // ## LZW Reader
@@ -165,12 +212,17 @@ pub type DeflateReader<R> = flate2::read::ZlibDecoder<R>;
 pub struct LZWReader<R: Read> {
     reader: BufReader<Take<R>>,
     decoder: weezl::decode::Decoder,
+    is_old_style: bool,
 }
 
 #[cfg(feature = "lzw")]
 impl<R: Read> LZWReader<R> {
     /// Wraps a reader
-    pub fn new(reader: R, compressed_length: usize) -> LZWReader<R> {
+    pub fn new(
+        reader: R,
+        compressed_length: usize,
+        engine: &mut CompressionEngines,
+    ) -> LZWReader<R> {
         let mut buffered = BufReader::with_capacity(
             (32 * 1024).min(compressed_length),
             reader.take(u64::try_from(compressed_length).unwrap()),
@@ -188,26 +240,75 @@ impl<R: Read> LZWReader<R> {
             Ok(head) if head.len() >= 2 && head[0] == 0x00 && head[1] & 0x01 != 0
         );
 
-        let configuration = if old_style {
+        let decoder = if old_style {
             weezl::decode::Configuration::new(weezl::BitOrder::Lsb, 8)
+                .with_yield_on_full_buffer(true)
+                .build()
         } else {
-            weezl::decode::Configuration::with_tiff_size_switch(weezl::BitOrder::Msb, 8)
-        }
-        .with_yield_on_full_buffer(true);
+            // All standard LZW decoders have the same configuration. We can thus reuse any that we
+            // have previously constructed, skipping internal buffer allocation. We only need to
+            // reset them to a new stream.
+            if let Some(mut lzw) = engine.lzw.take() {
+                lzw.reset();
+                lzw
+            } else {
+                weezl::decode::Configuration::with_tiff_size_switch(weezl::BitOrder::Msb, 8)
+                    .with_yield_on_full_buffer(true)
+                    .build()
+            }
+        };
 
         Self {
             reader: buffered,
-            decoder: configuration.build(),
+            decoder: decoder,
+            is_old_style: old_style,
         }
+    }
+
+    fn discard_n(&mut self, mut n: u64) -> io::Result<()> {
+        let mut buf = [0u8; 2048];
+
+        while n > 0 {
+            let limit = n.min(2048) as usize;
+            let result = self
+                .decoder
+                .decode_bytes(self.reader.fill_buf()?, &mut buf[..limit]);
+
+            self.reader.consume(result.consumed_in);
+            n -= result.consumed_out as u64;
+
+            match result.status {
+                Ok(weezl::LzwStatus::Ok) => {
+                    continue;
+                }
+                Ok(weezl::LzwStatus::NoProgress) => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        "no lzw end code found",
+                    ));
+                }
+                Ok(weezl::LzwStatus::Done) => {
+                    if n != 0 {
+                        // stream is too short.
+                        return Err(std::io::ErrorKind::UnexpectedEof)?;
+                    }
+                }
+                Err(err) => return Err(io::Error::new(io::ErrorKind::InvalidData, err)),
+            }
+        }
+
+        Ok(())
     }
 }
 
 #[cfg(feature = "lzw")]
 impl<R: Read> Read for LZWReader<R> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, mut buf: &mut [u8]) -> io::Result<usize> {
         loop {
             let result = self.decoder.decode_bytes(self.reader.fill_buf()?, buf);
+
             self.reader.consume(result.consumed_in);
+            let _ = buf.split_off_mut(..result.consumed_out);
 
             match result.status {
                 Ok(weezl::LzwStatus::Ok) => {
@@ -228,6 +329,24 @@ impl<R: Read> Read for LZWReader<R> {
                 }
                 Err(err) => return Err(io::Error::new(io::ErrorKind::InvalidData, err)),
             }
+        }
+    }
+}
+
+impl<R: Read> ReadSamples for LZWReader<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+
+        if discard > 0 {
+            self.discard_n(discard)?;
+        }
+
+        Ok(())
+    }
+
+    fn cache_or_destroy(self: Box<Self>, engines: &mut CompressionEngines) {
+        if !self.is_old_style && engines.lzw.is_none() {
+            engines.lzw = Some(self.decoder);
         }
     }
 }
@@ -301,6 +420,14 @@ impl<R: Read> Read for PackBitsReader<R> {
             self.state = PackBitsReaderState::Header;
         }
         Ok(actual)
+    }
+}
+
+impl<R: Read> ReadSamples for PackBitsReader<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
     }
 }
 
@@ -417,6 +544,14 @@ impl<R: Read> Read for Group4Reader<R> {
         }
 
         self.line_buf.read(buf)
+    }
+}
+
+impl<R: Read> ReadSamples for Group4Reader<R> {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
     }
 }
 
@@ -558,6 +693,14 @@ impl Read for Group3Reader {
     }
 }
 
+impl ReadSamples for Group3Reader {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
+    }
+}
+
 #[cfg(feature = "webp")]
 pub struct WebPReader {
     inner: Cursor<Vec<u8>>,
@@ -610,6 +753,15 @@ impl WebPReader {
 impl Read for WebPReader {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.read(buf)
+    }
+}
+
+#[cfg(feature = "webp")]
+impl ReadSamples for WebPReader {
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
     }
 }
 

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -124,6 +124,9 @@ impl<R: Read> EndianReader<R> {
 
 /// A variant of `io::Read` that takes one block to the end.
 ///
+/// This is derived from `Read` so that any special optimization done by `std` (or any nightly crate
+/// for that matter) surely remains usable.
+///
 /// We want our decompression engines to be much more specialized than the standard library trait.
 /// Firstly there is more information available to communicate (the tiff Type, known decompressed
 /// size, …) and secondly they can potentially *reset*. This could be solved with an extension trait
@@ -134,9 +137,7 @@ impl<R: Read> EndianReader<R> {
 /// discarding data *after* it is put into the output buffer. Yet, for some decompression that write
 /// alone is considerable work where it could simply skip bits more efficiently. So the reader would
 /// likely want to know about a sample mask.
-pub trait ReadSamples {
-    fn read_samples(&mut self, buf: &mut [u8]) -> io::Result<()>;
-
+pub trait ReadSamples: Read {
     /// Read a row of samples and throw away some additional padding samples at the end.
     ///
     /// This is automatically implemented for `Self: Read` as a copy into `io::Sink`.
@@ -144,10 +145,6 @@ pub trait ReadSamples {
 }
 
 impl<R: Read> ReadSamples for R {
-    fn read_samples(&mut self, buf: &mut [u8]) -> io::Result<()> {
-        self.read_exact(buf)
-    }
-
     fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
         self.read_exact(buf)?;
         std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -122,6 +122,39 @@ impl<R: Read> EndianReader<R> {
 // # READERS
 //
 
+/// A variant of `io::Read` that takes one block to the end.
+///
+/// We want our decompression engines to be much more specialized than the standard library trait.
+/// Firstly there is more information available to communicate (the tiff Type, known decompressed
+/// size, …) and secondly they can potentially *reset*. This could be solved with an extension trait
+/// but since we want to avoid `read` in favor of `read_exact` (or an equivalent if we want to pass
+/// in a strided block buffer) a separate trait that's auto derived is favored.
+///
+/// FIXME: Also consider that we will want to read subsets of samples. Via IO this is done by
+/// discarding data *after* it is put into the output buffer. Yet, for some decompression that write
+/// alone is considerable work where it could simply skip bits more efficiently. So the reader would
+/// likely want to know about a sample mask.
+pub trait ReadSamples {
+    fn read_samples(&mut self, buf: &mut [u8]) -> io::Result<()>;
+
+    /// Read a row of samples and throw away some additional padding samples at the end.
+    ///
+    /// This is automatically implemented for `Self: Read` as a copy into `io::Sink`.
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()>;
+}
+
+impl<R: Read> ReadSamples for R {
+    fn read_samples(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        self.read_exact(buf)
+    }
+
+    fn read_padded_samples(&mut self, buf: &mut [u8], discard: u64) -> io::Result<()> {
+        self.read_exact(buf)?;
+        std::io::copy(&mut self.by_ref().take(discard), &mut std::io::sink())?;
+        Ok(())
+    }
+}
+
 /// Type alias for the deflate Reader
 #[cfg(feature = "deflate")]
 pub type DeflateReader<R> = flate2::read::ZlibDecoder<R>;


### PR DESCRIPTION
Tiled images utilize the same compression type in all their tiles, but each is an independently compressed stream of bytes. For many compression methods it would be more efficient to re-use some existing decompression engine so that allocated intermediate buffers, tables, etc. can be re-used.

Also, skipping bytes such as extra samples or padding samples at the end of a tile's right edge can sometimes be done much more efficiently than by copying these bytes to an output buffer as required by the `Read` trait. We don't make much use of this but it cleans up code.